### PR TITLE
Add blank line before Returns block.

### DIFF
--- a/lib/xcode_support.bzl
+++ b/lib/xcode_support.bzl
@@ -26,6 +26,7 @@ def _is_xcode_at_least_version(xcode_config, version):
     Args:
         xcode_config: The XcodeVersionConfig provider from the `_xcode_config` attribute's value.
         version: The minimum desired Xcode version, as a dotted version string.
+
     Returns:
         True if the given `xcode_config` version at least as high as the requested version.
     """


### PR DESCRIPTION
Add blank line before Returns block.

The new buildifier --lint things "Returns" is an argument to the function
unless there is a blank line before it.