### PR TITLE
Simplify the running of buildifier on CI.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,7 +1,21 @@
 ---
-platforms:
-  macos:
+tasks:
+  macos_latest:
+    name: "Latest Bazel"
+    platform: macos
+    bazel: latest
     build_targets:
     - "//..."
     test_targets:
     - "//..."
+
+  macos_last_green:
+    name: "Last Green Bazel"
+    platform: macos
+    bazel: last_green
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+
+buildifier: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ matrix:
       sudo: false
       language: c++
       env: BUILDIFIER=RELEASE
-    # The normal macOS builds.
-    - env: BAZEL=HEAD TARGET=//...
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Apple Support for [Bazel](https://bazel.build)
 
 [![Build Status](https://travis-ci.org/bazelbuild/apple_support.svg?branch=master)](https://travis-ci.org/bazelbuild/apple_support)
+[![Build Status](https://badge.buildkite.com/6739ca70cb485ecec4ec403f4d6775269728aece4bb984127f.svg)](https://buildkite.com/bazel/apple-support-darwin)
 
 This repository contains helper methods that support building rules that target
 Apple platforms.

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -55,43 +55,30 @@ if [[ -n "${BUILDIFIER:-}" ]]; then
 
   # Check for format issues?
   if [[ "${FORMAT:-yes}" == "yes" ]] ; then
-    # bazelbuild/buildtools/issues/220 - diff doesn't include the file that needs updating
-    if ! find . "${FIND_ARGS[@]}" -print | xargs buildifier -d > /dev/null 2>&1 ; then
-      if [[ "${FOUND_ISSUES}" != "no" ]] ; then
-        echo ""
-      fi
-      echo "ERROR: BUILD/.bzl file formatting issue(s):"
-      echo ""
-      # bazelbuild/buildtools/issues/329 - sed out the exit status lines.
-      find . "${FIND_ARGS[@]}" -print -exec buildifier -v -d {} \; \
-          2>&1 | sed -E -e '/^exit status 1$/d'
+    echo "buildifier: validating formatting..."
+    if ! find . "${FIND_ARGS[@]}" -print | xargs buildifier -d ; then
       echo ""
       echo "Please download the latest buildifier"
       echo "   https://github.com/bazelbuild/buildtools/releases"
       echo "and run it over the changed BUILD/.bzl files."
+      echo ""
       FOUND_ISSUES="yes"
     fi
   fi
 
   # Check for lint issues?
   if [[ "${LINT:-yes}" == "yes" ]] ; then
+    echo "buildifier: running lint checks..."
     # NOTE: buildifier defaults to --mode=fix, so these lint runs also
     # reformat the files. But since this is on travis, that is fine.
     # https://github.com/bazelbuild/buildtools/issues/453
-    if ! find . "${FIND_ARGS[@]}" -print | xargs buildifier --lint=warn > /dev/null 2>&1 ; then
-      if [[ "${FOUND_ISSUES}" != "no" ]] ; then
-        echo ""
-      fi
-      echo "ERROR: BUILD/.bzl lint issue(s):"
-      echo ""
-      # buildifier now exits with error if there are issues, so use `|| true`
-      # to keep the script running.
-      find . "${FIND_ARGS[@]}" -print | xargs buildifier --lint=warn || true
+    if ! find . "${FIND_ARGS[@]}" -print | xargs buildifier --lint=warn ; then
       echo ""
       echo "Please download the latest buildifier"
       echo "   https://github.com/bazelbuild/buildtools/releases"
       echo "and run it with --lint=(warn|fix) over the changed BUILD/.bzl files"
       echo "and make the edits as needed."
+      echo ""
       FOUND_ISSUES="yes"
     fi
   fi


### PR DESCRIPTION
Simplify the running of buildifier on CI.

As of 0.22.0 there are enough improvements in outputs and exit codes that
it seems to make more sense to no longer try to pretty the results and
just rely on a run and exit status to add a footer telling folks how
to fix up things if something is found.