### PR TITLE
Fix Buildifier version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,4 +18,4 @@ tasks:
     test_targets:
     - "//..."
 
-buildifier: true
+buildifier: latest


### PR DESCRIPTION
"buildifier: true" has been deprecated by https://github.com/bazelbuild/continuous-integration/pull/542