### PR TITLE
Travis CI Cleanup.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,4 +18,4 @@ tasks:
     test_targets:
     - "//..."
 
-buildifier: true
+buildifier: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,4 @@
-os: osx
-# Not really swift, but stops travis from saying it is ruby.
-language: swift
 
-# Travis does not use osx_image when it computes the matrix itself, if we want
-# to test on multiple versions, then it required manually building the matrix
-# to set a different osx_image for each configuration.
-osx_image: xcode10.1
-
-# Build out the matrix ourselves so we can set multiple variables.
-# - `BAZEL`: Used in `before_install` to pick the version of bazel to use,
-#    "RELEASE" extracts from https://github.com/bazelbuild/bazel/releases/latest,
-#    otherwise it is the tag to fetch.
-# - `TARGET`: Are used in the `script` to issue a build `script` phase will be
-#    used for `bazel test`.
 matrix:
   include:
     # One build on linux to run buildifier since linux agents are faster on travis.

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -35,47 +35,6 @@ function github_latest_release_tag() {
 }
 
 # -------------------------------------------------------------------------------------------------
-# Helper to get a download url out of bazel build metadata file.
-function url_from_bazel_manifest() {
-  local MANIFEST_URL=$1
-    if [[ "${OS}" == "darwin" ]]; then
-      local JSON_OS="macos"
-    else
-      local JSON_OS="ubuntu1404"
-    fi
-  wget -O - "${MANIFEST_URL}" \
-    | python -c "import json; import sys; print json.load(sys.stdin)['platforms']['${JSON_OS}']['url']"
-}
-
-# -------------------------------------------------------------------------------------------------
-# Helper to install bazel.
-function install_bazel() {
-  local VERSION="${1}"
-
-  if [[ "${VERSION}" == "RELEASE" ]]; then
-    VERSION="$(github_latest_release_tag bazelbuild/bazel)"
-  fi
-
-  # macOS and trusty images have jdk8, so install bazel without jdk.
-  if [[ "${VERSION}" == "HEAD" ]]; then
-    # bazelbuild/continuous-integration/issues/234 - they don't seem to have an installed
-    # just raw binaries?
-    mkdir -p "$HOME/bin"
-    wget -O "$HOME/bin/bazel" \
-      "$(url_from_bazel_manifest https://storage.googleapis.com/bazel-builds/metadata/latest.json)"
-    chmod +x "$HOME/bin/bazel"
-  else
-    wget -O install.sh \
-      "https://github.com/bazelbuild/bazel/releases/download/${VERSION}/bazel-${VERSION}-without-jdk-installer-${OS}-x86_64.sh"
-    chmod +x install.sh
-    ./install.sh --user
-    rm -f install.sh
-  fi
-
-  bazel version
-}
-
-# -------------------------------------------------------------------------------------------------
 # Helper to install buildifier.
 function install_buildifier() {
   local VERSION="${1}"
@@ -103,5 +62,4 @@ function install_buildifier() {
 
 # -------------------------------------------------------------------------------------------------
 # Install what is requested.
-[[ -z "${BAZEL:-}" ]] || install_bazel "${BAZEL}"
 [[ -z "${BUILDIFIER:-}" ]] || install_buildifier "${BUILDIFIER}"

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -17,26 +17,6 @@
 set -eu
 
 # -------------------------------------------------------------------------------------------------
-# Asked to do a bazel build.
-if [[ -n "${BAZEL:-}" ]]; then
-  # - Crank down the progress messages to not flood the travis log, but still
-  #   provide some output so there is an indicator things aren't hung.
-  # - "--test_output=errors" causes failures to report more completely since
-  #   just getting the log file info isn't that useful on CI.
-  set -x
-  TEST_ARGS=(
-    test
-    --show_progress_rate_limit=30.0
-    --test_output=errors
-  )
-  if [[ -n "${TAGS:-}" ]]; then
-    TEST_ARGS+=( "--test_tag_filters=${TAGS}")
-  fi
-  bazel "${TEST_ARGS[@]}" "${TARGET}"
-  set +x
-fi
-
-# -------------------------------------------------------------------------------------------------
 # Asked to do a buildifier run.
 if [[ -n "${BUILDIFIER:-}" ]]; then
   FOUND_ISSUES="no"


### PR DESCRIPTION
Travis CI Cleanup.

Bazel's BuildKite seems to be fine for the bazel builds, so remove the support
for doing bazel builds on Travis.

Note: Keeping the matrix as a manual build and some of the conditions in the
scripts just to reduce the chances of something not being right, as eventually
the BuildKite setup will match the buildifier support and these files will
just get dropped.