### PR TITLE
Update contributing information.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,58 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+# How to Contribute
 
-### Before you contribute
-**Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1)
-(CLA)**, which you can do online.
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
 
-The CLA is necessary mainly because you own the copyright to your changes,
-even after your contribution becomes part of our codebase, so we need your
-permission to use and distribute your code. We also need to be sure of
-various other things — for instance that you'll tell us if you know that
-your code infringes on other people's patents. You don't have to sign
-the CLA until after you've submitted your code for review and a member has
-approved it, but you must do it before we can put your code into our codebase.
+## File or claim an issue
 
-Before you start working on a larger contribution, you should get in touch
-with us first. Use the issue tracker to explain your idea so we can help and
-possibly guide you.
+Please let us know what you're working on if you want to change or add to the
+project. Before undertaking something, please file an issue or claim an existing
+issue.
 
-### Code reviews and other contributions.
-**All submissions, including submissions by project members, require review.**
-Please follow the instructions in [the contributors documentation](http://bazel.io/contributing.html).
+All significant changes/additions should also be discussed before they can be
+accepted. This gives all participants a chance to validate the design and to
+avoid duplication of effort. Ensuring that there is an issue for discussion
+before working on a PR helps everyone provide input/discussion/advice and
+avoid a PR having to get restarted based on useful feedback.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than
-the one above, the
-[Software Grant and Corporate Contributor License Agreement](https://cla.developers.google.com/about/google-corporate).
+We use [labels](https://github.com/bazelbuild/apple_support/labels) for the
+issues and pull requests to help track priorities, things being considered,
+deferred, etc. A project owner will try to update labels every week or so, as
+workloads permit.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Setting up your development environment
+
+To enforce a consistent code style through our code base, we use `buildifier`
+from the [bazelbuild/buildtools](https://github.com/bazelbuild/buildtools) to
+format `BUILD` and `*.bzl` files. We also use `buildifier --lint=warn` to check
+for common issues.
+
+You can download `buildifier` from
+[bazelbuild/buildtools Releases Page](https://github.com/bazelbuild/buildtools/releases).
+
+Bazel's CI is configured to ensure that files in pull requests are formatted
+correctly and that there are no lint issues.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).


### PR DESCRIPTION
Update contributing information.

Since this isn't part of bazel's core projects, directly provide more info
instead of linking to docs they have been evolving as they work on their
processes.