### PR TITLE
Show the build status only for the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Support for [Bazel](https://bazel.build)
 
-[![Build Status](https://badge.buildkite.com/6739ca70cb485ecec4ec403f4d6775269728aece4bb984127f.svg)](https://buildkite.com/bazel/apple-support-darwin)
+[![Build Status](https://badge.buildkite.com/6739ca70cb485ecec4ec403f4d6775269728aece4bb984127f.svg?branch=master)](https://buildkite.com/bazel/apple-support-darwin)
 
 This repository contains helper methods that support building rules that target
 Apple platforms.


### PR DESCRIPTION
Show the build status only for the master branch.

Otherwise a test_* branch that doesn't currently pass turns the badge red
because it was the "most recent" build on buildkite.