### PR TITLE
Add config to test some deps at their heads.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -18,4 +18,17 @@ tasks:
     test_targets:
     - "//..."
 
+  macos_latest_head_deps:
+    name: "Latest Bazel"
+    platform: macos
+    bazel: latest
+    shell_commands:
+    # Update the WORKSPACE to use head versions of some deps to ensure nothing
+    # has landed on them breaking this project.
+    - .bazelci/update_workspace_to_deps_heads.sh
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+
 buildifier: latest

--- a/.bazelci/update_workspace_to_deps_heads.sh
+++ b/.bazelci/update_workspace_to_deps_heads.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Modify the WORKSPACE to pull in the master branches of some deps.
+sed \
+  -i "" \
+  -e \
+    '/^workspace.*/a \
+\
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")\
+\
+git_repository(\
+\    name = "bazel_skylib",\
+\    remote = "https://github.com/bazelbuild/bazel-skylib.git",\
+\    branch = "master",\
+)\
+' \
+  WORKSPACE


### PR DESCRIPTION
Add config to test some deps at their heads.

Add a helper script and new ci config to run the script modifying the
WORKSPACE to get head versions of some dependencies to help catch if
they were to land something that would break the build.