### PR TITLE
Add missing BUILD dep introduced by https://github.com/bazelbuild/apple_support/commit/e5588297491dfb4c546fbe13571a94e1e8a0929a.

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -7,6 +7,7 @@ bzl_library(
     name = "bzl_library",
     srcs = glob(["*.bzl"]),
     visibility = ["//:__pkg__"],
+    deps = ["@bazel_skylib//lib:types"],
 )
 
 # Consumed by bazel tests.


### PR DESCRIPTION
Add missing BUILD dep introduced by https://github.com/bazelbuild/apple_support/commit/e5588297491dfb4c546fbe13571a94e1e8a0929a.