### PR TITLE
Move apple version tests to Skylark where possible.

### DIFF
--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -38,7 +38,7 @@ def apple_support_dependencies():
         http_archive,
         name = "bazel_skylib",
         urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
         ],
-        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
     )


### PR DESCRIPTION
Move apple version tests to Skylark where possible.

Two issues are making it impossible to migrate all tests:
 - The `embed_label` flag is not in the configuration and can't be modified in a transition
 - Some of the failures we test for happen when the action is run(the tool throws errors) and the Skylark testing framework currently doesn't have a way to test failures outside of the Analysis stage.