### PR TITLE
Adopt bazel_skylib 1.0.

### DIFF
--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -38,7 +38,7 @@ def apple_support_dependencies():
         http_archive,
         name = "bazel_skylib",
         urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.9.0/bazel_skylib-0.9.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.0/bazel-skylib-1.0.0.tar.gz",
         ],
-        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
+        sha256 = "e72747100a8b6002992cc0bf678f6279e71a3fd4a88cab3371ace6c73432be30",
     )


### PR DESCRIPTION
Adopt bazel_skylib 1.0.