### PR TITLE
Set execution requirements for Starlark rules that use apple_support based on the availability of the selected Xcode.

### DIFF
--- a/rules/apple_genrule.bzl
+++ b/rules/apple_genrule.bzl
@@ -66,7 +66,7 @@ def _apple_genrule_impl(ctx):
         ),
         tools = ctx.attr.tools,
         label_dict = label_dict,
-        execution_requirements = apple_support.action_required_execution_requirements(),
+        execution_requirements = apple_support.action_required_execution_requirements(ctx),
     )
 
     message = ctx.attr.message or "Executing apple_genrule"

--- a/test/apple_support_test.bzl
+++ b/test/apple_support_test.bzl
@@ -193,7 +193,7 @@ def _apple_support_test_impl(ctx):
     ), is_executable = True)
 
     return [
-        testing.ExecutionInfo(apple_support.action_required_execution_requirements()),
+        testing.ExecutionInfo(apple_support.action_required_execution_requirements(ctx)),
         testing.TestEnvironment(apple_support.action_required_env(ctx)),
         DefaultInfo(
             executable = test_script,


### PR DESCRIPTION
Set execution requirements for Starlark rules that use apple_support based on the availability of the selected Xcode.

This is part of a series of changes that set the execution requirements for actions generated by rules that require Xcodes. The dynamic scheduler will later be modified to run those actions locally/remotely accordingly, but this does not currently change behavior.

RELNOTES: None.
