### PR TITLE
Created a macro to replace the wrapper macros used to determine platform features from ctx in the Apple BUILD Rules today.

### DIFF
--- a/doc/apple_support.md
+++ b/doc/apple_support.md
@@ -94,6 +94,7 @@ A dictionary with environment variables required for Xcode path resolution.
 
 <pre style="white-space: normal">
 apple_support.action_required_execution_requirements(<a href="#apple_support.action_required_execution_requirements.ctx">ctx</a>)
+apple_support.action_required_execution_requirements(<a href="#apple_support.action_required_execution_requirements.xcode_config">xcode_config</a>)
 </pre>
 
 Returns a dictionary with the execution requirements for running actions on Apple platforms.
@@ -116,7 +117,14 @@ test action.
   <tbody>
     <tr id="apple_support.action_required_execution_requirements.ctx">
       <td><code>ctx</code></td>
-      <td><p><code>Required</code></p><p>The context of the rule registering the action.</p></td>
+      <td><p><code>Optional</code></p><p>The context of the rule registering the action. Deprecated.</p></td>
+    </tr>
+    <tr id="apple_support.action_required_execution_requirements.xcode_config">
+      <td><code>xcode_config</code></td>
+      <td><p><code>Optional</code></p><p>The <code>apple_common.XcodeVersionConfig</code>
+            provider as found in the current rule or aspect's context. Typically from
+            <code>ctx.attr._xcode_config[apple_common.XcodeVersionConfig]</code>. Required if
+            <code>ctx</code> is not provided.</p></td>
     </tr>
   </tbody>
 </table>

--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -184,7 +184,7 @@ def _action_required_env(ctx):
         apple_common.target_apple_env(xcode_config, platform),
     )
 
-def _action_required_execution_requirements(ctx):
+def _action_required_execution_requirements(ctx = None, *, xcode_config = None):
     """Returns a dictionary with the execution requirements for running actions on Apple platforms.
 
     In most cases, you should _not_ use this API. It exists solely for using it on test rules,
@@ -195,15 +195,23 @@ def _action_required_execution_requirements(ctx):
     test action.
 
     Args:
-        ctx: The context of the rule registering the action.
+        ctx: The context of the rule registering the action. Deprecated.
+        xcode_config: The xcode_config as found in the current rule or aspect's
+            context. Typically from `ctx.attr._xcode_config[apple_common.XcodeVersionConfig]`.
+            Required if ctx is not given.
 
     Returns:
         A dictionary with execution requirements for running actions on Apple platforms.
     """
 
     # TODO(steinman): Replace this with xcode_config.execution_info once it is exposed.
+    if ctx != None and xcode_config != None:
+        fail("Can't specify both ctx and xcode_config.")
+    elif ctx == None and xcode_config == None:
+        fail("Must specify either ctx or xcode_config.")
     execution_requirements = {"requires-darwin": "1"}
-    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    if not xcode_config:
+        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
     if xcode_config:
         if xcode_config.availability() == "remote":
             execution_requirements["no-local"] = "1"


### PR DESCRIPTION
Migrated app_assets_validation partial and bitcode_symbols partial to use that new macro instead of ctx, passing the rest of the inputs through as arguments that were previously obtained through directly accessing ctx.

PiperOrigin-RevId: 330988093