### PR TITLE
For `apple_genrule`, use the `exec` configuration for `tools` and app…

### DIFF
--- a/rules/apple_genrule.bzl
+++ b/rules/apple_genrule.bzl
@@ -103,8 +103,9 @@ _apple_genrule_inner = rule(
         "executable": attr.bool(default = False),
         "message": attr.string(),
         "no_sandbox": attr.bool(),
-        "tools": attr.label_list(cfg = "host", allow_files = True),
+        "tools": attr.label_list(cfg = "exec", allow_files = True),
     }),
+    exec_compatible_with = ["@platforms//os:macos"],
     output_to_genfiles = True,
     fragments = ["apple"],
 )


### PR DESCRIPTION
…ly the correct execution platform constraint to the rule.

PiperOrigin-RevId: 351374444
(cherry picked from commit 59817b9f747fb954edeeb914be5d2068f85a0b57)