### PR TITLE
Move target_environment to apple_support so it can be relied upon by rules_swift and rules_apple.

### DIFF
--- a/constraints/BUILD
+++ b/constraints/BUILD
@@ -1,0 +1,26 @@
+# Standard constraint_settings and constraint_values for items common to rules_swift and rules_apple.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+filegroup(
+    name = "srcs",
+    srcs = ["BUILD"],
+)
+
+# Constraint indicating the target environment (e.g. device, simulator).
+constraint_setting(
+    name = "target_environment",
+    visibility = ["//visibility:private"],
+)
+
+constraint_value(
+    name = "device",
+    constraint_setting = ":target_environment",
+)
+
+constraint_value(
+    name = "simulator",
+    constraint_setting = ":target_environment",
+)


### PR DESCRIPTION
PiperOrigin-RevId: 355196884
(cherry picked from commit 5117edbfd73838c3e64366ff28b5cc4ec3ef33fe)