### PR TITLE
Add the Catalyst constraint to the list of target environments.

### DIFF
--- a/constraints/BUILD
+++ b/constraints/BUILD
@@ -24,3 +24,8 @@ constraint_value(
     name = "simulator",
     constraint_setting = ":target_environment",
 )
+
+constraint_value(
+    name = "catalyst",
+    constraint_setting = ":target_environment",
+)


### PR DESCRIPTION
This aligns with the LLVM triple representing this platform as a variant of iOS.

PiperOrigin-RevId: 358194575
(cherry picked from commit 84ad2df29043b0c8f7eef150dd73f30d2e5216d0)