### PR TITLE
Remove ctx support from path_placeholders.platform_frameworks().

### DIFF
--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -41,24 +41,16 @@ def _validate_actions_arg_requirements(*, ctx, actions):
     elif ctx == None and actions == None:
         fail("Must specify actions with xcode_config and apple_fragment.")
 
-def _platform_frameworks_path_placeholder(ctx = None, *, apple_fragment = None):
+def _platform_frameworks_path_placeholder(*, apple_fragment):
     """Returns the platform's frameworks directory, anchored to the Xcode path placeholder.
 
     Args:
-        ctx: The context of the rule that will register an action. Deprecated.
         apple_fragment: A reference to the apple fragment. Typically from `ctx.fragments.apple`.
-            Required if ctx is not given.
 
     Returns:
         Returns a string with the platform's frameworks directory, anchored to the Xcode path
         placeholder.
     """
-    if ctx != None and apple_fragment != None:
-        fail("Can't specify ctx with apple_fragment.")
-    elif ctx == None and apple_fragment == None:
-        fail("Must specify either ctx or apple_fragment.")
-    elif ctx != None:
-        apple_fragment = ctx.fragments.apple
     return "{xcode_path}/Platforms/{platform_name}.platform/Developer/Library/Frameworks".format(
         platform_name = apple_fragment.single_arch_platform.name_in_plist,
         xcode_path = _xcode_path_placeholder(),

--- a/test/apple_support_test.bzl
+++ b/test/apple_support_test.bzl
@@ -129,6 +129,10 @@ def _apple_support_test_impl(ctx):
         arguments = [run_output.path],
     )
 
+    platform_frameworks = apple_support.path_placeholders.platform_frameworks(
+        apple_fragment = ctx.fragments.apple,
+    )
+
     apple_support.run(
         ctx,
         outputs = [run_output_xcode_path_in_args],
@@ -136,9 +140,7 @@ def _apple_support_test_impl(ctx):
         arguments = [
             run_output_xcode_path_in_args.path,
             "XCODE_PATH_ARG={}".format(apple_support.path_placeholders.xcode()),
-            "FRAMEWORKS_PATH_ARG={}".format(
-                apple_support.path_placeholders.platform_frameworks(ctx),
-            ),
+            "FRAMEWORKS_PATH_ARG={}".format(platform_frameworks),
             "SDKROOT_PATH_ARG={}".format(apple_support.path_placeholders.sdkroot()),
         ],
         xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
@@ -149,7 +151,7 @@ def _apple_support_test_impl(ctx):
         "XCODE_PATH_ARG={}".format(apple_support.path_placeholders.xcode()),
     )
     action_args.add(
-        "FRAMEWORKS_PATH_ARG={}".format(apple_support.path_placeholders.platform_frameworks(ctx)),
+        "FRAMEWORKS_PATH_ARG={}".format(platform_frameworks),
     )
     action_args.add(
         "SDKROOT_PATH_ARG={}".format(apple_support.path_placeholders.sdkroot()),


### PR DESCRIPTION
RELNOTES: apple_support.path_placeholders.platform_frameworks() no longer accepts a ctx argument.
PiperOrigin-RevId: 364873873
(cherry picked from commit 9c175c7f47c476006491be5dce510a15f05067df)