### PR TITLE
Remove some of the extra depset work.

### DIFF
--- a/rules/BUILD
+++ b/rules/BUILD
@@ -10,7 +10,6 @@ bzl_library(
     deps = [
         "//lib:apple_support",
         "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:paths",
     ],
 )
 


### PR DESCRIPTION
- outputs isn't a depset, always a list, so don't make a depset to have to call to_list()
- inputs can be a depset, so don't flatten
- Remove the use of skylib's paths, and just fetch dirname from the File

RELNOTES: None
PiperOrigin-RevId: 366162426
(cherry picked from commit ec1cd1ffa5a91e6f57b92ee4f7a6de26717f1b22)