### PR TITLE
Add a module with methods to create actions that invoke `lipo`.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//lib:apple_support",
+        "//lib:lipo",
         "//lib:xcode_support",
         "//rules:apple_genrule",
     ],

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -12,6 +12,15 @@ bzl_library(
     ],
 )
 
+bzl_library(
+    name = "lipo",
+    srcs = ["lipo.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":apple_support",
+    ],
+)
+
 # Public bzl_library for anything that needs to depend on xcode_support.bzl.
 bzl_library(
     name = "xcode_support",

--- a/lib/lipo.bzl
+++ b/lib/lipo.bzl
@@ -1,0 +1,64 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""APIs for operating on universal binaries with `lipo`."""
+
+load(":apple_support.bzl", "apple_support")
+
+def _create(
+        *,
+        actions,
+        inputs,
+        output,
+        apple_fragment,
+        xcode_config):
+    """Creates a universal binary by combining other binaries.
+
+    Args:
+        actions: The `Actions` object used to register actions.
+        inputs: A sequence or `depset` of `File`s that represent binaries to
+            be combined. As with the `lipo` tool's `-create` command (when
+            invoked without the `-arch` option) all of the architectures in
+            each input file will be copied into the output file (so the inputs
+            may be either single-architecture binaries or universal binaries).
+        output: A `File` representing the universal binary that will be the
+            output of the action.
+        apple_fragment: The `apple` configuration fragment used to configure
+            the action environment.
+        xcode_config: The `apple_common.XcodeVersionConfig` provider used to
+            configure the action environment.
+    """
+    if not inputs:
+        fail("lipo.create requires at least one input file.")
+
+    args = actions.args()
+    args.add("-create")
+    args.add_all(inputs)
+    args.add("-output", output)
+
+    apple_support.run(
+        actions = actions,
+        arguments = [args],
+        executable = "/usr/bin/lipo",
+        inputs = inputs,
+        outputs = [output],
+        apple_fragment = apple_fragment,
+        xcode_config = xcode_config,
+    )
+
+# TODO(apple-rules-team): Add support for other mutating operations here if
+# there is a need: extract, extract_family, remove, replace, thin.
+lipo = struct(
+    create = _create,
+)


### PR DESCRIPTION
Currently, this only supports `create`, but could support other `lipo` actions in the future.

PiperOrigin-RevId: 373572887
(cherry picked from commit d381321b41bcfc1a7b657c7f3c2ba66b9cea4e40)