### PR TITLE
Add `universal_binary` rule to build multi-arch macOS binaries

### DIFF
--- a/lib/macos_universal_binary.bzl
+++ b/lib/macos_universal_binary.bzl
@@ -1,0 +1,70 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation for macOS universal binary rule."""
+
+load(":apple_support.bzl", "apple_support")
+load(":lipo.bzl", "lipo")
+load(":transitions.bzl", "macos_universal_transition")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
+def _macos_universal_binary_impl(ctx):
+    inputs = [
+        binary.files.to_list()[0]
+        for binary in ctx.split_attr.binary.values()
+    ]
+
+    if not inputs:
+        fail("Target (%s) `binary` label ('%s') does not provide any " +
+             "file for universal binary" % (ctx.attr.name, ctx.attr.binary))
+
+    fat_binary = ctx.actions.declare_file(ctx.label.name)
+
+    lipo.create(
+        actions = ctx.actions,
+        apple_fragment = ctx.fragments.apple,
+        inputs = inputs,
+        output = fat_binary,
+        xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
+    )
+
+    return [
+        DefaultInfo(
+            executable = fat_binary,
+            files = depset([fat_binary]),
+        ),
+    ]
+
+macos_universal_binary = rule(
+    attrs = dicts.add(
+        apple_support.action_required_attrs(),
+        {
+            "binary": attr.label(
+                cfg = macos_universal_transition,
+                doc = "Target to generate a 'fat' binary from.",
+                mandatory = True,
+            ),
+            "_allowlist_function_transition": attr.label(
+                default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+            ),
+        },
+    ),
+    doc = """
+This rule produces a multi-architecture ("fat") binary targeting Apple macOS
+platforms *regardless* the architecture of the host platform. The `lipo` tool
+is used to combine built binaries of multiple architectures.
+""",
+    fragments = ["apple"],
+    implementation = _macos_universal_binary_impl,
+)

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -17,14 +17,14 @@
 def _macos_universal_transition_impl(settings, attr):
     _ignore = [attr]
 
-    if not settings["//command_line_option:cpu"].startswith("darwin"):
-        fail("`macos_universal_transition` can't be used with a non-macOS cpu")
-
     # Create a split transition from any macOS cpu to a list of all macOS cpus
-    return [
-        {"//command_line_option:cpu": "darwin_x86_64"},
-        {"//command_line_option:cpu": "darwin_arm64"},
-    ]
+    if settings["//command_line_option:cpu"].startswith("darwin"):
+        return [
+            {"//command_line_option:cpu": "darwin_x86_64"},
+            {"//command_line_option:cpu": "darwin_arm64"},
+        ]
+    else:
+        return settings
 
 macos_universal_transition = transition(
     implementation = _macos_universal_transition_impl,

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -1,0 +1,33 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transition support."""
+
+def _macos_universal_transition_impl(settings, attr):
+    _ignore = [attr]
+
+    if not settings["//command_line_option:cpu"].startswith("darwin"):
+        fail("`macos_universal_transition` can't be used with a non-macOS cpu")
+
+    # Create a split transition from any macOS cpu to a list of all macOS cpus
+    return [
+        {"//command_line_option:cpu": "darwin_x86_64"},
+        {"//command_line_option:cpu": "darwin_arm64"},
+    ]
+
+macos_universal_transition = transition(
+    implementation = _macos_universal_transition_impl,
+    inputs = ["//command_line_option:cpu"],
+    outputs = ["//command_line_option:cpu"],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,6 +1,7 @@
 load("//rules:apple_genrule.bzl", "apple_genrule")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":apple_support_test.bzl", "apple_support_test")
+load(":universal_binary_test.bzl", "universal_binary_test")
 load(":xcode_support_test.bzl", "xcode_support_test")
 
 licenses(["notice"])
@@ -32,4 +33,24 @@ bzl_library(
         "//lib:apple_support",
         "//lib:xcode_support",
     ],
+)
+
+universal_binary_test(
+    name = "universal_binary_test_x86_64",
+    binary_contains_symbols = [
+        "__Z19function_for_x86_64v",
+        "__Z19function_for_arch64v",
+    ],
+    cpu = "darwin_x86_64",
+    target_under_test = "//test/test_data:multi_arch_cc_binary",
+)
+
+universal_binary_test(
+    name = "universal_binary_test_arm64",
+    binary_contains_symbols = [
+        "__Z19function_for_x86_64v",
+        "__Z19function_for_arch64v",
+    ],
+    cpu = "darwin_arm64",
+    target_under_test = "//test/test_data:multi_arch_cc_binary",
 )

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -1,0 +1,26 @@
+load(
+    "//lib:universal_binary.bzl",
+    "universal_binary",
+)
+
+package(
+    default_testonly = 1,
+    default_visibility = ["//test:__subpackages__"],
+)
+
+TARGETS_UNDER_TEST_TAGS = [
+    "manual",
+    "notap",
+]
+
+cc_binary(
+    name = "cc_test_binary",
+    srcs = ["main.cc"],
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+universal_binary(
+    name = "multi_arch_cc_binary",
+    binary = ":cc_test_binary",
+    tags = TARGETS_UNDER_TEST_TAGS,
+)

--- a/test/test_data/main.cc
+++ b/test/test_data/main.cc
@@ -1,0 +1,32 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// C++ binary with basic hello world for universal Apple binary tests.
+
+#include <iostream>
+
+
+#if defined(__x86_64__)
+void function_for_x86_64() {
+  std::cout << "Compiled for x86_64" << std::endl;
+}
+#elif defined(__aarch64__)
+void function_for_arch64() {
+  std::cout << "Compiled for arm64" << std::endl;
+}
+#endif
+
+int main(int argc, char** argv) {
+  return 0;
+}

--- a/test/universal_binary_test.bzl
+++ b/test/universal_binary_test.bzl
@@ -1,0 +1,114 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Definition of a test rule to test universal_binary."""
+
+# Template for the test script used to validate that the action outputs contain
+# the expected values.
+_TEST_SCRIPT_CONTENTS = """\
+#!/bin/bash
+
+set -eu
+
+newline=$'\n'
+
+SYMBOLS=(
+  {binary_contains_symbols}
+)
+
+if [[ ! -f "{file}" ]]; then
+  echo "{file} doesn't exist"
+  exit 1
+fi
+
+actual_symbols=$(objdump -t -macho -arch=x86_64 -arch arm64 {file} | grep -v "*UND*" | awk '{{print substr($0,index($0,$5))}}')
+for symbol in "${{SYMBOLS[@]}}"; do
+  echo "$actual_symbols" | grep -Fxq "$symbol" || \
+    (echo "In file: {file}"; \
+     echo "Expected symbol \"$symbol\" was not found. The " \
+       "symbols in the binary were:$newline$actual_symbols"; \
+     exit 1)
+done
+
+echo "Test passed"
+
+exit 0
+"""
+
+def _universal_binary_test_transition(settings, attr):
+    """Implementation of the universal_binary_test_transition transition."""
+
+    return {
+        "//command_line_option:cpu": attr.cpu,
+    }
+
+universal_binary_test_transition = transition(
+    implementation = _universal_binary_test_transition,
+    inputs = [],
+    outputs = ["//command_line_option:cpu"],
+)
+
+def _universal_binary_test_impl(ctx):
+    """Implementation of the universal_binary_test rule."""
+
+    target_under_test = ctx.split_attr.target_under_test.values()[0]
+    output_to_verify = target_under_test[DefaultInfo].files.to_list()[0]
+
+    test_script = ctx.actions.declare_file("{}_test_script".format(ctx.label.name))
+    test_script_contents = _TEST_SCRIPT_CONTENTS.format(
+        binary_contains_symbols = "\n  ".join([
+            x
+            for x in ctx.attr.binary_contains_symbols
+        ]),
+        file = output_to_verify.short_path,
+    )
+
+    ctx.actions.write(
+        content = test_script_contents,
+        is_executable = True,
+        output = test_script,
+    )
+
+    return [
+        DefaultInfo(
+            executable = test_script,
+            runfiles = ctx.runfiles(files = [output_to_verify]),
+        ),
+    ]
+
+universal_binary_test = rule(
+    attrs = {
+        "binary_contains_symbols": attr.string_list(
+            doc = """\
+A list of symbols that should appear in the binary file specified in
+`target_under_test`.""",
+            mandatory = True,
+        ),
+        "cpu": attr.string(
+            doc = "CPU to use for test under target.",
+        ),
+        "target_under_test": attr.label(
+            mandatory = True,
+            providers = [DefaultInfo],
+            doc = "The binary whose contents are to be verified.",
+            cfg = universal_binary_test_transition,
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    fragments = ["apple"],
+    implementation = _universal_binary_test_impl,
+    test = True,
+)

--- a/test/universal_binary_test.bzl
+++ b/test/universal_binary_test.bzl
@@ -19,7 +19,7 @@
 _TEST_SCRIPT_CONTENTS = """\
 #!/bin/bash
 
-set -eu
+set -euo pipefail
 
 newline=$'\n'
 

--- a/test/universal_binary_test.bzl
+++ b/test/universal_binary_test.bzl
@@ -32,7 +32,7 @@ if [[ ! -f "{file}" ]]; then
   exit 1
 fi
 
-actual_symbols=$(objdump -t -macho -arch=x86_64 -arch arm64 {file} | grep -v "*UND*" | awk '{{print substr($0,index($0,$5))}}')
+actual_symbols=$(nm -Uj -arch x86_64 -arch arm64 {file})
 for symbol in "${{SYMBOLS[@]}}"; do
   echo "$actual_symbols" | grep -Fxq "$symbol" || \
     (echo "In file: {file}"; \


### PR DESCRIPTION
This is basically a copy of the new `apple_universal_binary` rule but
with a simpler interface (there are no `minimum_os_version` and
`platform_type` attributes), and the output binary is forced to be
multi-arch. This rule is meant to be used for host/exec tools so that
they are built as universal binaries regardless the architecture of the
execution platform.
