### PR TITLE
Fix apple_genrule

### DIFF
--- a/rules/apple_genrule.bzl
+++ b/rules/apple_genrule.bzl
@@ -75,14 +75,15 @@ def _apple_genrule_impl(ctx):
     if ctx.attr.no_sandbox:
         extra_args["execution_requirements"] = {"no-sandbox": "1"}
 
-    apple_support.run_shell(
+    apple_support.run(
         actions = ctx.actions,
         xcode_config = xcode_config,
         apple_fragment = ctx.fragments.apple,
+        executable = argv[0],
+        arguments = argv[1:],
         inputs = depset(resolved_inputs, transitive = [resolved_srcs]),
         outputs = files_to_build,
         env = ctx.configuration.default_shell_env,
-        command = " ".join(argv),
         progress_message = "%s %s" % (message, ctx.label),
         mnemonic = "Genrule",
         input_manifests = runfiles_manifests,

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,6 @@
 load("//rules:apple_genrule.bzl", "apple_genrule")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(":apple_support_test.bzl", "apple_support_test")
 load(":xcode_support_test.bzl", "xcode_support_test")
 
@@ -19,10 +20,21 @@ sh_test(
     data = ["simple_genrule.txt"],
 )
 
+build_test(
+    name = "touched_test",
+    targets = [":touched"],
+)
+
 apple_genrule(
     name = "simple_genrule",
     outs = ["simple_genrule.txt"],
     cmd = "printenv | grep \"^\\(DEVELOPER_DIR\\|SDKROOT\\)\" > $(@)",
+)
+
+apple_genrule(
+    name = "touched",
+    outs = ["genrule_touched.txt"],
+    cmd = "touch $(OUTS)",
 )
 
 bzl_library(


### PR DESCRIPTION
[`ctx.resolve_command()`](https://docs.bazel.build/versions/main/skylark/lib/ctx.html#resolve_command) seems to return a list of arguments like `["/bin/bash", "-c", "mycommand"]`. These were being simply joined with a single whitespace and passed into `run_shell()`, effectively concatenated into `/bin/bash -c mycommand`. This works fine if the command doesn't have any arguments but fails if it does:

```
INFO: Analyzed 21 targets (0 packages loaded, 0 targets configured).
INFO: Found 17 targets and 4 test targets...
ERROR: /code/apple_support/test/BUILD:34:14: Executing apple_genrule //test:touched failed: (Exit 1): bash failed: error executing command /bin/bash -c '/bin/bash -c touch bazel-out/darwin-fastbuild/bin/test/genrule_touched.txt'

Use --sandbox_debug to see verbose messages from the sandbox
usage: touch [-A [-][[hh]mm]SS] [-achm] [-r file] [-t [[CC]YY]MMDDhhmm[.SS]]
       [-d YYYY-MM-DDThh:mm:SS[.frac][tz]] file ...
INFO: Elapsed time: 0.700s, Critical Path: 0.55s
```

The test I added initially failed, but then passed after my change to `apple_genrule.bzl`.