### PR TITLE
Change `cfg` to `"exec"` for xcode_path_wrapper.

### DIFF
--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -158,7 +158,7 @@ def _action_required_attrs():
             ),
         ),
         "_xcode_path_wrapper": attr.label(
-            cfg = "host",
+            cfg = "exec",
             executable = True,
             default = Label("@build_bazel_apple_support//tools:xcode_path_wrapper"),
         ),


### PR DESCRIPTION
The binary is a `sh_binary`, so it likely doesn't matter, but should be more correct.

b/204580651 will likely result in more follow up here (atleast with guidance for the things that use this apis that need these).

PiperOrigin-RevId: 406829632
(cherry picked from commit fd0e5ba0b07e30ac3a12c86bda5b2c8431db6d88)
