### PR TITLE
Move `universal_binary.bzl` to the `rules` directory

### DIFF
--- a/rules/universal_binary.bzl
+++ b/rules/universal_binary.bzl
@@ -14,9 +14,9 @@
 
 """Implementation for macOS universal binary rule."""
 
-load(":apple_support.bzl", "apple_support")
-load(":lipo.bzl", "lipo")
-load(":transitions.bzl", "macos_universal_transition")
+load("//lib:apple_support.bzl", "apple_support")
+load("//lib:lipo.bzl", "lipo")
+load("//lib:transitions.bzl", "macos_universal_transition")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 def _universal_binary_impl(ctx):

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -1,5 +1,5 @@
 load(
-    "//lib:universal_binary.bzl",
+    "//rules:universal_binary.bzl",
     "universal_binary",
 )
 


### PR DESCRIPTION
The `lib` directory is for Starlark modules.
