### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-* @BalestraPatrick
-* @brentleyjones
-* @keith
-* @segiddins
-* @thii
+* @BalestraPatrick @brentleyjones @keith @segiddins @thii


### PR DESCRIPTION
CODEOWNERS files are read from bottom to top. Once one line matches, it'll get applied and lines above don't. So all reviewers for the same pattern need to be on the same line.