### PR TITLE
Bump MODULE.bazel to 1.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "apple_support",
     compatibility_level = 1,
-    version = "0.13.0",
+    version = "1.0.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.1.1")


### PR DESCRIPTION
As explained in https://github.com/bazelbuild/bazel-central-registry/pull/122#issuecomment-1174830206, this version doesn't really matter for now, but good to keep it up to date if we can.