### PR TITLE
Add all standard platforms

### DIFF
--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,0 +1,154 @@
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "macos_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:macos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "macos_arm64e",
+    constraint_values = [
+        "@platforms//cpu:arm64e",
+        "@platforms//os:macos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "ios_i386",
+    constraint_values = [
+        "@platforms//cpu:i386",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "ios_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "ios_sim_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "ios_armv7",
+    constraint_values = [
+        "@platforms//cpu:armv7",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "ios_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "ios_arm64e",
+    constraint_values = [
+        "@platforms//cpu:arm64e",
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "tvos_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:tvos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "tvos_sim_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:tvos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "tvos_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:tvos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "watchos_i386",
+    constraint_values = [
+        "@platforms//cpu:i386",
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "watchos_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "watchos_arm64",
+    constraint_values = [
+        "@platforms//cpu:arm64",
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+platform(
+    name = "watchos_armv7k",
+    constraint_values = [
+        "@platforms//cpu:armv7k",
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+platform(
+    name = "watchos_arm64_32",
+    constraint_values = [
+        "@platforms//cpu:arm64_32",
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)


### PR DESCRIPTION
These platforms can be used in the case you want to use bazel platforms
support. If you need more customization for remote execution you can use
these as the parent platforms for your custom ones.