### PR TITLE
Explicitly create the containing directory to avoid an occassional error from lipo; "can't create temporary output file [...] (Permission denied)".

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -18,6 +18,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         ":apple_support",
+        "@bazel_skylib//lib:shell",
     ],
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 463400246
(cherry picked from commit 6ed0d77fc4ee23b317846888e399e299acaadec8)