### PR TITLE
Allow FilesToRunProvider type executable in apple_support.run.

### DIFF
--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -363,7 +363,14 @@ def _run(
     # to then work within the arguments list.
     executable_args = actions.args()
     original_executable = processed_kwargs.pop("executable")
-    executable_args.add(original_executable)
+
+    # actions.run supports multiple executable types. (File; or string; or FilesToRunProvider)
+    # If the passed in executable is a FilesToRunProvider, only add the main executable to the
+    # should be added to the executable args.
+    if type(original_executable) == "FilesToRunProvider":
+        executable_args.add(original_executable.executable)
+    else:
+        executable_args.add(original_executable)
     all_arguments.append(executable_args)
 
     # Append the original arguments to the full list of arguments, after the original executable.


### PR DESCRIPTION
This is useful for passing in native binaries (e.g. java_binary).

PiperOrigin-RevId: 473255419
(cherry picked from commit 6022b1bc7d0e0928e0c9baad809df196a9b22075)

Fixes https://github.com/bazelbuild/apple_support/issues/131
