### PR TITLE
Add repo_name to module definition

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "apple_support",
     compatibility_level = 1,
+    repo_name = "build_bazel_apple_support",
     version = "1.3.1",
 )
 


### PR DESCRIPTION
This was [recently added to Bazel](https://github.com/bazelbuild/bazel/commit/73ed74ec5da1e787e2bffb19ebca6c94c437aa38) and will help in keeping the repository name the same during the migration period. 

We will need to remember to add this attribute to the `MODULE.bazel` checked-in into the `bazel-central-registry` once we cut a new release.