### PR TITLE
Skip `swizzle_absolute_xcttestsourcelocation` on non-macOS platforms

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -11,6 +11,12 @@ objc_library(
     name = "swizzle_absolute_xcttestsourcelocation",
     testonly = True,
     srcs = ["swizzle_absolute_xcttestsourcelocation.m"],
+    target_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//os:watchos",
+        "@platforms//os:ios",
+        "@platforms//os:tvos",
+    ],
     visibility = ["//visibility:public"],
     alwayslink = True,
 )


### PR DESCRIPTION
This target isn't compatible with any other platform other than macOS so we're now declaring its compatibility. This was discovered during the bzlmod integration: https://github.com/bazelbuild/bazel-central-registry/pull/196