### PR TITLE
Revert "Skip `swizzle_absolute_xcttestsourcelocation` on non-macOS platforms (#137)"

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -11,12 +11,6 @@ objc_library(
     name = "swizzle_absolute_xcttestsourcelocation",
     testonly = True,
     srcs = ["swizzle_absolute_xcttestsourcelocation.m"],
-    target_compatible_with = [
-        "@platforms//os:macos",
-        "@platforms//os:watchos",
-        "@platforms//os:ios",
-        "@platforms//os:tvos",
-    ],
     visibility = ["//visibility:public"],
     alwayslink = True,
 )


### PR DESCRIPTION
This reverts commit a7ef1baaff1e001e3c713d73d3ccfcfeaef7f967.
