### PR TITLE
Skip `swizzle_absolute_xcttestsourcelocation` on non-macOS platforms

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -11,6 +11,13 @@ objc_library(
     name = "swizzle_absolute_xcttestsourcelocation",
     testonly = True,
     srcs = ["swizzle_absolute_xcttestsourcelocation.m"],
+    target_compatible_with = select({
+        "@platforms//os:ios": [],
+        "@platforms//os:macos": [],
+        "@platforms//os:tvos": [],
+        "@platforms//os:watchos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     visibility = ["//visibility:public"],
     alwayslink = True,
 )


### PR DESCRIPTION
Retries to land a7ef1baaff1e001e3c713d73d3ccfcfeaef7f967. Turns out we need a `select` in order to OR all the platforms and throw an incompatible error as the default case. I tested this with close to latest Bazel HEAD/rules_apple/rules_swift to reproduce the error seen in afdf55010f9c5fc5b73b6f1b01bcc05b20ab31e7. After this patch, the error went away.