### PR TITLE
Migrate analysis_lipo_test to analysis_target_action_test

### DIFF
--- a/lib/lipo.bzl
+++ b/lib/lipo.bzl
@@ -62,6 +62,7 @@ def _create(
     apple_support.run_shell(
         actions = actions,
         command = " ".join(command),
+        mnemonic = "AppleLipo",
         inputs = inputs,
         outputs = [output],
         apple_fragment = apple_fragment,


### PR DESCRIPTION
Introduce `expected_env` attribute to the analysis_target_action_test
which can be leveraged to match target action environment values for
lipo actions.

- Introduce `expected_env` attr to the analysis_target_action_test.
- Migrates analysis_lipo_test rule to the analysis_target_action_test.
- Add missing mnemonic to apple_support lipo action.

PiperOrigin-RevId: 469299855
(cherry picked from commit 97c47e0a1d4d155ce390866cba0a724e69e35015)
