### PR TITLE
Remove automerge from create-release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,7 +36,6 @@ jobs:
           git commit -m "$msg"
           git push -u origin "$tmp_branch"
           gh pr create --title "$msg" --body ""
-          gh pr merge --auto --squash "$tmp_branch"
 
           COPYFILE_DISABLE=1 tar czvf "apple_support.$TAG.tar.gz" ./*
           ./.github/generate-notes.sh "$TAG" | tee notes.md


### PR DESCRIPTION
The bot token doesn't have access to do this. Not a huge deal for us to
enable / manually merge.
