### PR TITLE
Add publish-to-bcr app configuration

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,20 @@
+{
+    "homepage": "https://github.com/bazelbuild/apple_support",
+    "maintainers": [
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "name": "Keith Smiley"
+        },
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/apple_support"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,14 @@
+matrix:
+  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+
+tasks:
+  verify_targets:
+    name: "Build targets under //lib"
+    platform: ${{ platform }}
+    build_targets:
+    - '@apple_support//lib/...'
+  run_tests:
+    name: "Run test targets"
+    platform: "macos"
+    test_targets:
+    - '@apple_support//test/...'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/bazelbuild/apple_support/releases/download/{TAG}/apple_support.{TAG}.tar.gz"
+}


### PR DESCRIPTION
These configuration files are needed to get https://github.com/bazel-contrib/publish-to-bcr to publish new releases to the [bazel-central-registry](https://github.com/bazel-contrib/publish-to-bcr) every time a new release is cut.