### PR TITLE
Add __BAZEL_EXECUTION_ROOT__ command line replacement

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1847,7 +1847,7 @@ def _impl(ctx):
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [flag_group(flags = ["-fdebug-prefix-map=__BAZEL_EXECROOT__=."])],
+                flag_groups = [flag_group(flags = ["-fdebug-prefix-map=__BAZEL_EXECUTION_ROOT__=."])],
             ),
         ],
     )
@@ -2094,7 +2094,7 @@ def _impl(ctx):
             flag_set(
                 actions = all_link_actions +
                           ["objc-executable", "objc++-executable"],
-                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,__BAZEL_EXECROOT__/"])],
+                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,__BAZEL_EXECUTION_ROOT__/"])],
             ),
         ],
     )

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1847,7 +1847,7 @@ def _impl(ctx):
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [flag_group(flags = ["DEBUG_PREFIX_MAP_PWD=."])],
+                flag_groups = [flag_group(flags = ["-fdebug-prefix-map=__BAZEL_EXECROOT__=."])],
             ),
         ],
     )
@@ -2094,7 +2094,7 @@ def _impl(ctx):
             flag_set(
                 actions = all_link_actions +
                           ["objc-executable", "objc++-executable"],
-                flag_groups = [flag_group(flags = ["OSO_PREFIX_MAP_PWD"])],
+                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,__BAZEL_EXECROOT__/"])],
             ),
         ],
     )

--- a/crosstool/wrapped_clang.cc
+++ b/crosstool/wrapped_clang.cc
@@ -313,16 +313,9 @@ void ProcessArgument(const std::string arg, const std::string developer_dir,
     return;
   }
 
-  std::string dest_dir, bitcode_symbol_map;
-  if (SetArgIfFlagPresent(arg, "DEBUG_PREFIX_MAP_PWD", &dest_dir)) {
-    new_arg = "-fdebug-prefix-map=" + cwd + "=" + dest_dir;
-  }
-  if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
-    new_arg = "-Wl,-oso_prefix," + cwd + "/";
-  }
-
   FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &new_arg);
   FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &new_arg);
+  FindAndReplace("__BAZEL_EXECROOT__", cwd, &new_arg);
 
   // Make the `add_ast_path` options used to embed Swift module references
   // absolute to enable Swift debugging without dSYMs: see

--- a/crosstool/wrapped_clang.cc
+++ b/crosstool/wrapped_clang.cc
@@ -313,9 +313,9 @@ void ProcessArgument(const std::string arg, const std::string developer_dir,
     return;
   }
 
+  FindAndReplace("__BAZEL_EXECUTION_ROOT__", cwd, &new_arg);
   FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &new_arg);
   FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &new_arg);
-  FindAndReplace("__BAZEL_EXECUTION_ROOT__", cwd, &new_arg);
 
   // Make the `add_ast_path` options used to embed Swift module references
   // absolute to enable Swift debugging without dSYMs: see

--- a/crosstool/wrapped_clang.cc
+++ b/crosstool/wrapped_clang.cc
@@ -315,7 +315,7 @@ void ProcessArgument(const std::string arg, const std::string developer_dir,
 
   FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &new_arg);
   FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &new_arg);
-  FindAndReplace("__BAZEL_EXECROOT__", cwd, &new_arg);
+  FindAndReplace("__BAZEL_EXECUTION_ROOT__", cwd, &new_arg);
 
   // Make the `add_ast_path` options used to embed Swift module references
   // absolute to enable Swift debugging without dSYMs: see

--- a/test/shell/wrapped_clang_test.sh
+++ b/test/shell/wrapped_clang_test.sh
@@ -80,6 +80,13 @@ function test_sdkroot_remapping() {
   expect_log "sdkroot=mysdkroot" "Expected sdkroot to be remapped."
 }
 
+function test_execroot_remapped() {
+  env DEVELOPER_DIR=dummy SDKROOT=mysdkroot \
+      "${WRAPPED_CLANG}" "-fdebug-prefix-map=__BAZEL_EXECROOT__=." \
+      >$TEST_log || fail "wrapped_clang failed";
+  expect_log "-fdebug-prefix-map=/" "Expected execroot to be remapped."
+}
+
 function test_params_expansion() {
   params=$(mktemp)
   {

--- a/test/shell/wrapped_clang_test.sh
+++ b/test/shell/wrapped_clang_test.sh
@@ -82,7 +82,7 @@ function test_sdkroot_remapping() {
 
 function test_execroot_remapped() {
   env DEVELOPER_DIR=dummy SDKROOT=mysdkroot \
-      "${WRAPPED_CLANG}" "-fdebug-prefix-map=__BAZEL_EXECROOT__=." \
+      "${WRAPPED_CLANG}" "-fdebug-prefix-map=__BAZEL_EXECUTION_ROOT__=." \
       >$TEST_log || fail "wrapped_clang failed";
   expect_log "-fdebug-prefix-map=/" "Expected execroot to be remapped."
 }


### PR DESCRIPTION
This allows more generic flags to be passed that need to use the
execroot. This makes it easier for users to pass things like this
without requiring crosstool modifications
