### PR TITLE
Remove cc-compiler-darwin

### DIFF
--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -94,14 +94,6 @@ cc_toolchain_suite(
     for arch in OSX_TOOLS_ARCHS
 ]
 
-# When xcode_locator fails and causes cc_autoconf_toolchains to fall back
-# to the non-Xcode C++ toolchain, it uses the legacy cpu value to refer to
-# the toolchain, which is "darwin" for x86_64 macOS.
-alias(
-    name = "cc-compiler-darwin",
-    actual = ":cc-compiler-darwin_x86_64",
-)
-
 [
     cc_toolchain_config(
         name = arch,


### PR DESCRIPTION
This workaround is only for the case where xcode_locator fails. We do
not allow that to fail and do not fall back if it does
