### PR TITLE
Remove armeabi toolchain

### DIFF
--- a/crosstool/BUILD.toolchains
+++ b/crosstool/BUILD.toolchains
@@ -3,7 +3,6 @@ package(default_visibility = ["//visibility:public"])
 # Target constraints for each arch.
 # TODO(apple-rules): Rename osx constraint to macOS.
 OSX_TOOLS_CONSTRAINTS = {
-    "armeabi-v7a": ["@platforms//cpu:arm"],
     "darwin_arm64": [
         "@platforms//os:osx",
         "@platforms//cpu:arm64",

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -23,7 +23,6 @@ OSX_TOOLS_ARCHS = [
     "tvos_arm64",
 ] + OSX_TOOLS_NON_DEVICE_ARCHS
 
-load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 CC_TOOLCHAINS = [(
@@ -37,8 +36,6 @@ CC_TOOLCHAINS = [(
     ("darwin|clang", ":cc-compiler-darwin_x86_64"),
     ("k8", ":cc-compiler-darwin_x86_64"),
     ("darwin", ":cc-compiler-darwin_x86_64"),
-    ("armeabi-v7a|compiler", ":cc-compiler-armeabi-v7a"),
-    ("armeabi-v7a", ":cc-compiler-armeabi-v7a"),
 ]
 
 cc_library(
@@ -114,21 +111,3 @@ alias(
     )
     for arch in OSX_TOOLS_ARCHS
 ]
-
-# Android tooling requires a default toolchain for the armeabi-v7a cpu.
-cc_toolchain(
-    name = "cc-compiler-armeabi-v7a",
-    toolchain_identifier = "stub_armeabi-v7a",
-    toolchain_config = ":stub_armeabi-v7a",
-    all_files = ":empty",
-    ar_files = ":empty",
-    as_files = ":empty",
-    compiler_files = ":empty",
-    dwp_files = ":empty",
-    linker_files = ":empty",
-    objcopy_files = ":empty",
-    strip_files = ":empty",
-    supports_param_files = 1,
-)
-
-armeabi_cc_toolchain_config(name = "stub_armeabi-v7a")

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -143,7 +143,6 @@ def configure_osx_toolchain(repository_ctx):
       Whether or not configuration was successful
     """
     paths = resolve_labels(repository_ctx, [
-        "@bazel_tools//tools/cpp:armeabi_cc_toolchain_config.bzl",
         "@bazel_tools//tools/cpp:osx_cc_wrapper.sh.tpl",
         "@build_bazel_apple_support//crosstool:libtool.sh",
         "@build_bazel_apple_support//crosstool:libtool_check_unique.cc",
@@ -176,10 +175,6 @@ def configure_osx_toolchain(repository_ctx):
             "%{cc}": escape_string(cc_path),
             "%{env}": escape_string(get_env(repository_ctx)),
         },
-    )
-    repository_ctx.symlink(
-        paths["@bazel_tools//tools/cpp:armeabi_cc_toolchain_config.bzl"],
-        "armeabi_cc_toolchain_config.bzl",
     )
     repository_ctx.symlink(
         paths["@build_bazel_apple_support//crosstool:xcrunwrapper.sh"],


### PR DESCRIPTION
This was added because the NDK requires all toolchains have this in
bazel itself. Since this toolchain isn't part of bazel we no longer need
this.
