### PR TITLE
Add error for -Wincompatible-sysroot

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2049,6 +2049,7 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
+                            "-Werror=incompatible-sysroot",
                             "-Wshorten-64-to-32",
                             "-Wbool-conversion",
                             "-Wconstant-conversion",


### PR DESCRIPTION
If you ever hit this it's always a misconfiguration somewhere.
Realistically you only hit it if you're editing the rules but sometimes
if you don't stop immediately the rest of the output can be very noisy
and misleading.
