### PR TITLE
Make objc++-executable and objc-executable actions behave the same

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -187,8 +187,6 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 flag_groups = [
-                    flag_group(flags = ["-stdlib=libc++", "-std=gnu++11"]),
-                    flag_group(flags = ["-target", target_system_name]),
                     flag_group(
                         flags = [
                             "-Xlinker",
@@ -198,6 +196,12 @@ def _impl(ctx):
                             "-ObjC",
                         ],
                     ),
+                ],
+                with_features = [with_feature_set(not_features = ["kernel_extension"])],
+            ),
+            flag_set(
+                flag_groups = [
+                    flag_group(flags = ["-target", target_system_name]),
                     flag_group(
                         flags = ["-l%{library_names}"],
                         iterate_over = "library_names",
@@ -228,7 +232,7 @@ def _impl(ctx):
         ],
         tools = [
             tool(
-                path = "wrapped_clang_pp",
+                path = "wrapped_clang",
                 execution_requirements = xcode_execution_requirements,
             ),
         ],


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/commit/25be21130ba774e9f02cc39a010aafe64a3ab245
