### PR TITLE
Clarify how to use the `SDKROOT` and `DEVELOPER_DIR` env vars in `apple_genrule` because the distinction between `MAKE vars` and `env vars` isn't super clear.

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -53,13 +53,17 @@ The set of make variables that are supported for this rule:
         root directory in the genfiles tree, even if all the generated
         files belong to the same subdirectory.
 
-The following environment variables are added to the rule action:
+The following environment variables are defined when the rule is executed:
 
 * `DEVELOPER_DIR`: The base developer directory as defined on Apple
                    architectures, most commonly used in invoking Apple
                    tools such as xcrun.
 * `SDKROOT`: The base SDK directory as defined on Apple architectures, most
              commonly used in invoking Apple tools such as xcrun.
+
+NOTE: `DEVELOPER_DIR` and `SDKROOT` are environment variables and *not* make
+      variables. To refer to them in `cmd` you must use environment variable
+      syntax (i.e. using `$$`). Example: ```cmd = "xcrun --sdkroot $$SDKROOT clang...```
 
 
 **ATTRIBUTES**

--- a/rules/private/apple_genrule.bzl
+++ b/rules/private/apple_genrule.bzl
@@ -180,13 +180,17 @@ The set of make variables that are supported for this rule:
         root directory in the genfiles tree, even if all the generated
         files belong to the same subdirectory.
 
-The following environment variables are added to the rule action:
+The following environment variables are defined when the rule is executed:
 
 * `DEVELOPER_DIR`: The base developer directory as defined on Apple
                    architectures, most commonly used in invoking Apple
                    tools such as xcrun.
 * `SDKROOT`: The base SDK directory as defined on Apple architectures, most
              commonly used in invoking Apple tools such as xcrun.
+
+NOTE: `DEVELOPER_DIR` and `SDKROOT` are environment variables and *not* make
+      variables. To refer to them in `cmd` you must use environment variable
+      syntax (i.e. using `$$`). Example: ```cmd = "xcrun --sdkroot $$SDKROOT clang...```
 """,
     exec_compatible_with = ["@platforms//os:macos"],
     output_to_genfiles = True,


### PR DESCRIPTION
PiperOrigin-RevId: 506652228
(cherry picked from commit 5c5d8fa82a5ab95c1504a72e91cdf25db0afed98)
