### PR TITLE
Add BAZEL_SKIP_XCODE_FETCH to reduce toolchain configuration time

### DIFF
--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -156,9 +156,13 @@ def configure_osx_toolchain(repository_ctx):
         Label("@build_bazel_apple_support//crosstool:wrapped_clang.cc"),
     ))
 
-    (xcode_toolchains, xcodeloc_err) = run_xcode_locator(repository_ctx, xcode_locator)
-    if not xcode_toolchains:
-        return False
+    skip_xcode_fetch = "BAZEL_SKIP_XCODE_FETCH" in repository_ctx.os.environ and repository_ctx.os.environ["BAZEL_SKIP_XCODE_FETCH"] == "1"
+    xcode_toolchains = []
+    xcodeloc_err = ""
+    if not skip_xcode_fetch:
+        (xcode_toolchains, xcodeloc_err) = run_xcode_locator(repository_ctx, xcode_locator)
+        if not xcode_toolchains:
+            return False
 
     # For Xcode toolchains, there's no reason to use anything other than
     # wrapped_clang, so that we still get the Bazel Xcode placeholder


### PR DESCRIPTION
Since this toolchain requires Xcode, running xcode_locator during
toolchain setup is potentially duplicative. The only things it's used
for is to check that they exist, and to add to the allowed include
directories. The include directories already includes `/Applications`
which is where _most_ people likely have Xcode installed, so as long
as that can be relied on, fetching these values isn't necessary. This
saves a few seconds when the toolchain is reconfigured.

https://bazelbuild.slack.com/archives/CD3QY5C2X/p1652819625121889
