### PR TITLE
Add BAZEL_ALLOW_NON_APPLICATIONS_XCODE to run xcode-locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ toolchain works. Here are some of the more commonly useful ones:
   changes, which ensures that toolchain binaries will be rebuilt with
   the new version of Xcode so that caches are correctly shared across
   machines.
-- Setting `BAZEL_ALLOW_NON_APPLICATIONS_XCODE` in the environment allows
-  the toolchain to discover Xcode versions outside of the
-  `/Applications` to avoid header inclusion errors from bazel. This is
-  not enabled by default because `/Applications` is the standard
-  directory, and this improves toolchain setup performance.
+- Setting `BAZEL_ALLOW_NON_APPLICATIONS_XCODE=1` in the environment (or
+  using `--repo_env`) allows the toolchain to discover Xcode versions
+  outside of the `/Applications` directory to avoid header inclusion
+  errors from bazel. This is not enabled by default because
+  `/Applications` is the standard directory, and this improves toolchain
+  setup performance.
 
 [rules_apple]: https://github.com/bazelbuild/rules_apple

--- a/README.md
+++ b/README.md
@@ -67,4 +67,20 @@ your build for other reasons, you can use this toolchain with
 `platform_mappings` file. Please file any issues you find as you test
 this work in progress configuration.
 
+## Toolchain configuration
+
+There are many different flags you can flip to configure how the
+toolchain works. Here are some of the more commonly useful ones:
+
+- Setting `DEVELOPER_DIR` in the environment. This is recommended so
+  that the toolchain can be invalidated when the `DEVELOPER_DIR`
+  changes, which ensures that toolchain binaries will be rebuilt with
+  the new version of Xcode so that caches are correctly shared across
+  machines.
+- Setting `BAZEL_ALLOW_NON_APPLICATIONS_XCODE` in the environment allows
+  the toolchain to discover Xcode versions outside of the
+  `/Applications` to avoid header inclusion errors from bazel. This is
+  not enabled by default because `/Applications` is the standard
+  directory, and this improves toolchain setup performance.
+
 [rules_apple]: https://github.com/bazelbuild/rules_apple

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -134,9 +134,13 @@ def configure_osx_toolchain(repository_ctx):
         Label("@build_bazel_apple_support//crosstool:wrapped_clang.cc"),
     ))
 
-    (xcode_toolchains, xcodeloc_err) = run_xcode_locator(repository_ctx, xcode_locator)
-    if not xcode_toolchains:
-        return False, xcodeloc_err
+    xcode_toolchains = []
+    xcodeloc_err = ""
+    allow_non_applications_xcode = "BAZEL_ALLOW_NON_APPLICATIONS_XCODE" in repository_ctx.os.environ and repository_ctx.os.environ["BAZEL_ALLOW_NON_APPLICATIONS_XCODE"] == "1"
+    if allow_non_applications_xcode:
+        (xcode_toolchains, xcodeloc_err) = run_xcode_locator(repository_ctx, xcode_locator)
+        if not xcode_toolchains:
+            return False, xcodeloc_err
 
     # For Xcode toolchains, there's no reason to use anything other than
     # wrapped_clang, so that we still get the Bazel Xcode placeholder


### PR DESCRIPTION
Since this toolchain requires Xcode, running xcode_locator during
toolchain setup is likely duplicative. The only things it's used
for is to check that they exist, and to add to the allowed include
directories. The include directories already includes /Applications
which is where most people likely have Xcode installed, so as long
as that can be relied on, fetching these values isn't necessary. This
saves a few seconds when the toolchain is reconfigured.

bazelbuild.slack.com/archives/CD3QY5C2X/p1652819625121889
