### PR TITLE
Exclude some tests from bcr

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -12,3 +12,6 @@ tasks:
     platform: "macos"
     test_targets:
     - '@apple_support//test/...'
+    - '--'
+    - '-@apple_support//test/shell:apple_test'
+    - '-@apple_support//test/shell:objc_test'


### PR DESCRIPTION
These tests currently fail because of runfiles issues. Really we don't
care that the BCR tests much anyways, just that the file loads work at
all. Our CI covers the rest.

https://bazelbuild.slack.com/archives/C014RARENH0/p1676506451712139
