### PR TITLE
Flip defaults of hermetic debug info flags

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1657,6 +1657,7 @@ def _impl(ctx):
 
     relative_ast_path_feature = feature(
         name = "relative_ast_path",
+        enabled = True,
         env_sets = [
             env_set(
                 actions = _DYNAMIC_LINK_ACTIONS,
@@ -1777,6 +1778,7 @@ def _impl(ctx):
 
     remap_xcode_path_feature = feature(
         name = "remap_xcode_path",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = [
@@ -2010,6 +2012,7 @@ def _impl(ctx):
 
     oso_prefix_feature = feature(
         name = "oso_prefix_is_pwd",
+        enabled = True,
         flag_sets = [
             flag_set(
                 actions = _DYNAMIC_LINK_ACTIONS,


### PR DESCRIPTION
This flips the defaults of 3 features:

- relative_ast_path: this makes sure that the swift AST entries embedded
  in the final binaries uses relative paths for hermeticity. This could
  potentially break debugging for users relying on absolute paths, in
  which case they should use `platform settings -w "$PWD"` to change the
  lldb PWD so the relative paths are valid, or they should disable this
  feature.
- oso_prefix_is_pwd: this is similar to above except its for N_OSO
  entries in the final binary. The same workarounds apply
- remap_xcode_path: this removes absolute paths to Xcode from the
  binary. This shouldn't affect debugging because lldb's defaults should
  fall back to the same paths even if they aren't in the debug info
