### PR TITLE
Propagate xcode-locator error to fail()

### DIFF
--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -136,7 +136,7 @@ def configure_osx_toolchain(repository_ctx):
 
     (xcode_toolchains, xcodeloc_err) = run_xcode_locator(repository_ctx, xcode_locator)
     if not xcode_toolchains:
-        return False
+        return False, xcodeloc_err
 
     # For Xcode toolchains, there's no reason to use anything other than
     # wrapped_clang, so that we still get the Bazel Xcode placeholder
@@ -185,4 +185,4 @@ def configure_osx_toolchain(repository_ctx):
         },
     )
 
-    return True
+    return True, ""

--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -36,8 +36,8 @@ def _apple_cc_autoconf_impl(repository_ctx):
     if should_disable:
         repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled by {} env variable.".format(_DISABLE_ENV_VAR))
     elif repository_ctx.os.name.startswith("mac os"):
-        failed, error = configure_osx_toolchain(repository_ctx)
-        if failed:
+        success, error = configure_osx_toolchain(repository_ctx)
+        if not success:
             fail("Failed to configure Apple CC toolchain, if you only have the command line tools installed and not Xcode, you cannot use this toolchain. You should either remove it or temporarily set '{}=1' in the environment: {}".format(_DISABLE_ENV_VAR, error))
     else:
         repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled because you're not on macOS")

--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -36,8 +36,9 @@ def _apple_cc_autoconf_impl(repository_ctx):
     if should_disable:
         repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled by {} env variable.".format(_DISABLE_ENV_VAR))
     elif repository_ctx.os.name.startswith("mac os"):
-        if not configure_osx_toolchain(repository_ctx):
-            fail("Failed to configure Apple CC toolchain, if you only have the command line tools installed and not Xcode, you cannot use this toolchain. You should either remove it or temporarily set '{}=1' in the environment".format(_DISABLE_ENV_VAR))
+        failed, error = configure_osx_toolchain(repository_ctx)
+        if failed:
+            fail("Failed to configure Apple CC toolchain, if you only have the command line tools installed and not Xcode, you cannot use this toolchain. You should either remove it or temporarily set '{}=1' in the environment: {}".format(_DISABLE_ENV_VAR, error))
     else:
         repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled because you're not on macOS")
 


### PR DESCRIPTION
In the case xcode-locator fails to compile, the only error was the one
assuming you have no Xcode versions available
