### PR TITLE
Remove -ObjC from C++ links

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -191,7 +191,7 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
+                actions = [ACTION_NAMES.objc_executable, _OBJCPP_EXECUTABLE_ACTION_NAME],
                 flag_groups = [flag_group(flags = ["-ObjC"])],
                 with_features = [with_feature_set(not_features = ["kernel_extension"])],
             ),

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -17,22 +17,6 @@ disable_objc_test = make_action_command_line_test_rule(
 
 def linking_test_suite(name):
     default_test(
-        name = "{}_default_link_test".format(name),
-        tags = [name],
-        expected_argv = ["-ObjC"],
-        mnemonic = "CppLink",
-        target_under_test = "//test/test_data:cc_test_binary",
-    )
-
-    disable_objc_test(
-        name = "{}_disable_objc_link_test".format(name),
-        tags = [name],
-        not_expected_argv = ["-ObjC"],
-        mnemonic = "CppLink",
-        target_under_test = "//test/test_data:cc_test_binary",
-    )
-
-    default_test(
         name = "{}_default_apple_link_test".format(name),
         tags = [name],
         expected_argv = [


### PR DESCRIPTION
Since we went a different route in rules_swift and require the -ObjC
flag to be disabled there too, this isn't as necessary. This reduces the
risk of people making new reliance on -ObjC and when other changes land
to flip the default on this we won't have to worry about that case.
