### PR TITLE
[RFC] Add support for alternate linkers

### DIFF
--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -104,6 +104,13 @@ cc_toolchain_suite(
 %{cxx_builtin_include_directories}
         ],
         tool_paths_overrides = {%{tool_paths_overrides}},
+        alternate_linker_path = %{alternate_linker_path},
+        alternate_linker_args = [
+%{alternate_linker_args}
+        ],
+        default_linker_args = [
+%{default_linker_args}
+        ],
     )
     for arch in OSX_TOOLS_ARCHS
 ]

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -982,6 +982,17 @@ def _impl(ctx):
                     ),
                 ],
             ),
+            flag_set(
+                actions = _DYNAMIC_LINK_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = ctx.attr.default_linker_args,
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(not_features = ["alternate_linker"]),
+                ],
+            ),
         ],
     )
 
@@ -1001,6 +1012,22 @@ def _impl(ctx):
                 ],
                 with_features = [
                     with_feature_set(not_features = ["opt"]),
+                ],
+            ),
+        ],
+    )
+
+    alternate_linker_feature = feature(
+        name = "alternate_linker",
+        flag_sets = [
+            flag_set(
+                actions = _DYNAMIC_LINK_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "--ld-path={}".format(ctx.file.alternate_linker_path.path),
+                        ] + ctx.attr.alternate_linker_args,
+                    ),
                 ],
             ),
         ],
@@ -2574,6 +2601,7 @@ def _impl(ctx):
         default_link_flags_feature,
         no_deduplicate_feature,
         dead_strip_feature,
+        alternate_linker_feature,
         cpp_linker_flags_feature,
         apply_implicit_frameworks_feature,
         link_cocoa_feature,
@@ -2665,6 +2693,9 @@ cc_toolchain_config = rule(
         "cxx_builtin_include_directories": attr.string_list(),
         "tool_paths_overrides": attr.string_dict(),
         "extra_env": attr.string_dict(),
+        "default_linker_args": attr.string_list(),
+        "alternate_linker_path": attr.label(allow_single_file = True),
+        "alternate_linker_args": attr.string_list(),
         "_xcode_config": attr.label(default = configuration_field(
             fragment = "apple",
             name = "xcode_config_label",

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -106,7 +106,12 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
              "https://github.com/bazelbuild/apple_support/issues with the following:\n" +
              error_msg)
 
-def configure_osx_toolchain(repository_ctx):
+def configure_osx_toolchain(
+        *,
+        repository_ctx,
+        alternate_linker_path,
+        alternate_linker_args,
+        default_linker_args):
     """Configure C++ toolchain on macOS.
 
     Args:
@@ -186,6 +191,9 @@ def configure_osx_toolchain(repository_ctx):
             "%{tool_paths_overrides}": ",\n            ".join(
                 ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
             ),
+            "%{alternate_linker_path}": '"{}"'.format(alternate_linker_path) if alternate_linker_path else "None",
+            "%{alternate_linker_args}": ",\n".join(['"{}"'.format(arg) for arg in alternate_linker_args]),
+            "%{default_linker_args}": ",\n".join(['"{}"'.format(arg) for arg in default_linker_args]),
         },
     )
 


### PR DESCRIPTION
This is a RFC for adding support for using a different linker than the
default based on a new `--feature`. This is a theoretically replacement
for solutions like [`rules_apple_linker`](https://github.com/keith/rules_apple_linker/).

In some ways this is better, it's easier for users to integrate with,
without a separate rule set, and it's more clear what linker is going to
be used since it's explicitly global vs something in your dependency
tree. Also there is no ambiguity like there is with multiple linkers in
the dependency tree with rules_apple_linker.

This current iteration has some potential UX downsides, like it's harder
to select() on specific linker arguments, so users have to do that
themselves in their macros, but you cannot select() based on features.

Overall I think something like this is worth doing because many users
are interested in at least experimenting with this, and this decreases
the overhead to do so.
