### PR TITLE
Make `device` the default of `target_environment`

### DIFF
--- a/constraints/BUILD
+++ b/constraints/BUILD
@@ -12,6 +12,7 @@ filegroup(
 # Constraint indicating the target environment (e.g. device, simulator).
 constraint_setting(
     name = "target_environment",
+    default_constraint_value = ":device",
     visibility = ["//visibility:private"],
 )
 


### PR DESCRIPTION
This allows the registered macOS toolchains to match Bazel's auto- generated host platform for macOS.