### PR TITLE
Replace DEVELOPER_DIR remapping with '/PLACEHOLDER_DEVELOPER_DIR'

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1804,7 +1804,7 @@ def _impl(ctx):
                     ACTION_NAMES.objcpp_compile,
                 ],
                 flag_groups = [flag_group(flags = [
-                    "-fdebug-prefix-map=__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                    "-fdebug-prefix-map=__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
                 ])],
             ),
         ],


### PR DESCRIPTION
This makes it easier to understand this variable is different from
`$DEVELOPER_DIR` and also makes it "absolute" so that tools like
index-import don't try to absolutize it.
