### PR TITLE
Fix apple config setting group for 'darwin' CPU

### DIFF
--- a/configs/BUILD
+++ b/configs/BUILD
@@ -8,7 +8,7 @@ selects.config_setting_group(
     match_any = [
         cpu
         for cpu in APPLE_PLATFORMS_CONSTRAINTS.keys()
-    ],
+    ] + ["darwin"],
 )
 
 [
@@ -19,13 +19,19 @@ selects.config_setting_group(
     for cpu in APPLE_PLATFORMS_CONSTRAINTS.keys()
 ]
 
+# TODO: Remove all references to 'darwin' as a CPU once we no longer support bazel 6.x
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+)
+
 selects.config_setting_group(
     name = "any_device",
     match_any = [
         cpu
         for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()
         if "@build_bazel_apple_support//constraints:device" in constraints
-    ],
+    ] + ["darwin"],
 )
 
 selects.config_setting_group(


### PR DESCRIPTION
As of bazel 7.x 'darwin' as a CPU is no longer valid, and
'darwin_x86_64' is used instead. But while users of this config setting
might still be on older versions of bazel this adds support for that in
the config settings.
