### PR TITLE
Add stripped down apple_verification_test

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -5,6 +5,7 @@ load(":apple_support_test.bzl", "apple_support_test")
 load(":universal_binary_test.bzl", "universal_binary_test")
 load(":xcode_support_test.bzl", "xcode_support_test")
 load(":starlark_apple_binary.bzl", "starlark_apple_binary")
+load(":binary_tests.bzl", "binary_test_suite")
 load(":linking_tests.bzl", "linking_test_suite")
 
 licenses(["notice"])
@@ -13,6 +14,8 @@ licenses(["notice"])
 apple_support_test(name = "apple_support_test")
 
 xcode_support_test(name = "xcode_support_test")
+
+binary_test_suite(name = "binary")
 
 linking_test_suite(name = "linking")
 

--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -1,0 +1,17 @@
+"""Tests verifying produced binaries"""
+
+load(
+    "//test/rules:apple_verification_test.bzl",
+    "apple_verification_test",
+)
+
+def binary_test_suite(name):
+    apple_verification_test(
+        name = "{}_macos_binary_test".format(name),
+        tags = [name],
+        build_type = "device",
+        cpus = {"macos_cpus": "x86_64"},
+        expected_platform_type = "macos",
+        verifier_script = "//test/shell:verify_binary.sh",
+        target_under_test = "//test/test_data:apple_binary",
+    )

--- a/test/rules/apple_verification_test.bzl
+++ b/test/rules/apple_verification_test.bzl
@@ -26,14 +26,12 @@ def _transition_impl(_, attr):
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "x86_64",
             "//command_line_option:tvos_cpus": "x86_64",
-            "//command_line_option:visionos_cpus": "x86_64",
             "//command_line_option:watchos_cpus": "x86_64",
         })
     else:
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "arm64",
             "//command_line_option:tvos_cpus": "arm64",
-            "//command_line_option:visionos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
         })
 
@@ -53,7 +51,6 @@ _transition = transition(
         "//command_line_option:ios_signing_cert_name",
         "//command_line_option:macos_cpus",
         "//command_line_option:tvos_cpus",
-        "//command_line_option:visionos_cpus",
         "//command_line_option:watchos_cpus",
     ],
 )

--- a/test/rules/apple_verification_test.bzl
+++ b/test/rules/apple_verification_test.bzl
@@ -1,0 +1,146 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test rule to perform generic bundle verification tests."""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
+def _transition_impl(_, attr):
+    output_dictionary = {
+        "//command_line_option:cpu": "darwin_x86_64",
+        "//command_line_option:ios_signing_cert_name": "-",
+        "//command_line_option:macos_cpus": "x86_64",
+    }
+    if attr.build_type == "simulator":
+        output_dictionary.update({
+            "//command_line_option:ios_multi_cpus": "x86_64",
+            "//command_line_option:tvos_cpus": "x86_64",
+            "//command_line_option:visionos_cpus": "x86_64",
+            "//command_line_option:watchos_cpus": "x86_64",
+        })
+    else:
+        output_dictionary.update({
+            "//command_line_option:ios_multi_cpus": "arm64",
+            "//command_line_option:tvos_cpus": "arm64",
+            "//command_line_option:visionos_cpus": "arm64",
+            "//command_line_option:watchos_cpus": "arm64_32,armv7k",
+        })
+
+    if hasattr(attr, "cpus"):
+        for cpu_option, cpu in attr.cpus.items():
+            command_line_option = "//command_line_option:%s" % cpu_option
+            output_dictionary.update({command_line_option: cpu})
+
+    return output_dictionary
+
+_transition = transition(
+    implementation = _transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:cpu",
+        "//command_line_option:ios_multi_cpus",
+        "//command_line_option:ios_signing_cert_name",
+        "//command_line_option:macos_cpus",
+        "//command_line_option:tvos_cpus",
+        "//command_line_option:visionos_cpus",
+        "//command_line_option:watchos_cpus",
+    ],
+)
+
+def _apple_verification_test_impl(ctx):
+    binary = ctx.attr.target_under_test[0].files.to_list()[0]
+    output_script = ctx.actions.declare_file("{}_test_script".format(ctx.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file.verifier_script,
+        output = output_script,
+        substitutions = {
+            "%{binary}s": binary.short_path,
+        },
+        is_executable = True,
+    )
+
+    # Extra test environment to set during the test.
+    test_env = {
+        "BUILD_TYPE": ctx.attr.build_type,
+        "PLATFORM_TYPE": ctx.attr.expected_platform_type,
+    }
+
+    if ctx.attr.cpus:
+        cpu = ctx.attr.cpus.values()[0]
+        if cpu.startswith("sim_"):
+            cpu = cpu[4:]
+        test_env["CPU"] = cpu
+
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+
+    return [
+        testing.ExecutionInfo(xcode_config.execution_info()),
+        testing.TestEnvironment(dicts.add(
+            apple_common.apple_host_system_env(xcode_config),
+            test_env,
+        )),
+        DefaultInfo(
+            executable = output_script,
+            runfiles = ctx.runfiles(
+                files = [binary],
+            ),
+        ),
+    ]
+
+apple_verification_test = rule(
+    implementation = _apple_verification_test_impl,
+    attrs = {
+        "build_type": attr.string(
+            mandatory = True,
+            values = ["simulator", "device"],
+            doc = """
+Type of build for the target under test. Possible values are `simulator` or `device`.
+""",
+        ),
+        "expected_platform_type": attr.string(
+            doc = """
+The apple_platform_type the binary should have been built for.
+""",
+        ),
+        "cpus": attr.string_dict(
+            doc = """
+Dictionary of command line options cpu flags and the list of
+cpu's to use for test under target (e.g. {'ios_multi_cpus': ['arm64', 'x86_64']})
+""",
+        ),
+        "target_under_test": attr.label(
+            mandatory = True,
+            doc = "The binary being verified.",
+            cfg = _transition,
+        ),
+        "verifier_script": attr.label(
+            mandatory = True,
+            allow_single_file = [".sh"],
+            doc = """
+Script containing the verification code.
+""",
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+        "_xcode_config": attr.label(
+            default = configuration_field(
+                name = "xcode_config_label",
+                fragment = "apple",
+            ),
+        ),
+    },
+    test = True,
+    fragments = ["apple"],
+)

--- a/test/shell/BUILD
+++ b/test/shell/BUILD
@@ -1,3 +1,5 @@
+exports_files(["verify_binary.sh"])
+
 filegroup(
     name = "for_bazel_tests",
     testonly = True,

--- a/test/shell/verify_binary.sh
+++ b/test/shell/verify_binary.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly binary="%{binary}s"
+expected_platform="MACOS"
+if [[ "$PLATFORM_TYPE" == "ios" && "$BUILD_TYPE" == "device" ]]; then
+  expected_platform="IPHONEOS"
+elif [[ "$PLATFORM_TYPE" == "ios" && "$BUILD_TYPE" == "simulator" ]]; then
+  expected_platform="IPHONESIMULATOR"
+fi
+
+otool_output=$(otool -lv "$binary")
+if ! echo "$otool_output" | grep -q "platform $expected_platform"; then
+  echo "error: binary $binary does not contain platform $expected_platform, got: '$(echo "$otool_output" | grep platform || true)'"
+  exit 1
+fi
+
+lipo_output=$(lipo -info "$binary")
+if ! echo "$lipo_output" | grep -q "$CPU"; then
+  echo "error: binary $binary does not contain CPU $CPU, got: '$lipo_output"
+  exit 1
+fi

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -21,7 +21,7 @@ cc_binary(
 )
 
 cc_library(
-    name = "lib",
+    name = "cc_main",
     srcs = ["main.cc"],
     tags = TARGETS_UNDER_TEST_TAGS,
 )
@@ -34,6 +34,7 @@ universal_binary(
 
 starlark_apple_binary(
     name = "apple_binary",
+    platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,
-    deps = [":lib"],
+    deps = [":cc_main"],
 )


### PR DESCRIPTION
This is a useful test rule copied from rules_apple stripped down to only
what we need right now. This will allow us to remove some of our shell
tests, and write starlark tests instead of shell tests in the future.
