### PR TITLE
Add initial visionOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apple related [platforms](platforms/BUILD) and
 [constraints](constraints/BUILD) definitions, and small helper functions
 for rules authors targeting Apple platforms.
 
-If you want to build iOS, tvOS, watchOS, or macOS apps, use
+If you want to build iOS, tvOS, visionOS, watchOS, or macOS apps, use
 [`rules_apple`][rules_apple].
 
 If you want to build Swift use

--- a/configs/platforms.bzl
+++ b/configs/platforms.bzl
@@ -61,6 +61,21 @@ APPLE_PLATFORMS_CONSTRAINTS = {
         "@platforms//cpu:arm64",
         "@build_bazel_apple_support//constraints:simulator",
     ],
+    "visionos_arm64": [
+        "@platforms//os:visionos",
+        "@platforms//cpu:arm64",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+    "visionos_sim_arm64": [
+        "@platforms//os:visionos",
+        "@platforms//cpu:arm64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+    "visionos_x86_64": [
+        "@platforms//os:visionos",
+        "@platforms//cpu:x86_64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
     "watchos_arm64": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64",

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -683,9 +683,6 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_i386" or
         ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "ios_x86_64" or
-        ctx.attr.cpu == "visionos_arm64" or
-        ctx.attr.cpu == "visionos_sim_arm64" or
-        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or
         ctx.attr.cpu == "watchos_i386" or
@@ -725,7 +722,15 @@ def _impl(ctx):
             ],
         )
     else:
-        apply_default_compiler_flags_feature = None
+        apply_default_compiler_flags_feature = feature(
+            name = "apply_default_compiler_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                    flag_groups = [flag_group(flags = ["-fno-autolink"])],
+                ),
+            ],
+        )
 
     runtime_root_flags_feature = feature(
         name = "runtime_root_flags",

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -55,6 +55,8 @@ def _impl(ctx):
         target_system_name = "arm64-apple-ios{}".format(target_os_version)
     elif (ctx.attr.cpu == "tvos_arm64"):
         target_system_name = "arm64-apple-tvos{}".format(target_os_version)
+    elif (ctx.attr.cpu == "visionos_arm64"):
+        target_system_name = "arm64-apple-xros{}".format(target_os_version)
     elif (ctx.attr.cpu == "watchos_arm64_32"):
         target_system_name = "arm64_32-apple-watchos{}".format(target_os_version)
     elif (ctx.attr.cpu == "ios_arm64e"):
@@ -73,6 +75,8 @@ def _impl(ctx):
         target_system_name = "arm64-apple-ios{}-simulator".format(target_os_version)
     elif (ctx.attr.cpu == "tvos_sim_arm64"):
         target_system_name = "arm64-apple-tvos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "visionos_sim_arm64"):
+        target_system_name = "arm64-apple-xros{}-simulator".format(target_os_version)
     elif (ctx.attr.cpu == "watchos_arm64"):
         target_system_name = "arm64-apple-watchos{}-simulator".format(target_os_version)
     elif (ctx.attr.cpu == "darwin_x86_64"):
@@ -83,6 +87,8 @@ def _impl(ctx):
         target_system_name = "arm64e-apple-macosx{}".format(target_os_version)
     elif (ctx.attr.cpu == "tvos_x86_64"):
         target_system_name = "x86_64-apple-tvos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "visionos_x86_64"):
+        target_system_name = "x86_64-apple-xros{}-simulator".format(target_os_version)
     elif (ctx.attr.cpu == "watchos_x86_64"):
         target_system_name = "x86_64-apple-watchos{}-simulator".format(target_os_version)
     else:
@@ -101,7 +107,7 @@ def _impl(ctx):
         abi_version = "local"
 
     arch = ctx.attr.cpu.split("_", 1)[-1]
-    if ctx.attr.cpu in ["ios_sim_arm64", "tvos_sim_arm64", "watchos_arm64"]:
+    if ctx.attr.cpu in ["ios_sim_arm64", "tvos_sim_arm64", "visionos_sim_arm64", "watchos_arm64"]:
         arch = "arm64"
 
     all_link_actions = [
@@ -675,8 +681,11 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_arm64e" or
         ctx.attr.cpu == "ios_armv7" or
         ctx.attr.cpu == "ios_i386" or
-        ctx.attr.cpu == "ios_x86_64" or
         ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "visionos_arm64" or
+        ctx.attr.cpu == "visionos_sim_arm64" or
+        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or
         ctx.attr.cpu == "watchos_i386" or
@@ -864,6 +873,8 @@ def _impl(ctx):
         ctx.attr.cpu == "ios_sim_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "visionos_sim_arm64" or
+        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "watchos_i386" or
         ctx.attr.cpu == "watchos_x86_64" or
         ctx.attr.cpu == "watchos_arm64"):
@@ -1413,6 +1424,9 @@ def _impl(ctx):
         ctx.attr.cpu == "tvos_arm64" or
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "visionos_arm64" or
+        ctx.attr.cpu == "visionos_x86_64" or
+        ctx.attr.cpu == "visionos_sim_arm64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or
         ctx.attr.cpu == "watchos_i386" or

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -721,7 +721,11 @@ def _impl(ctx):
                 ),
             ],
         )
-    else:
+    elif (
+        ctx.attr.cpu == "visionos_arm64" or
+        ctx.attr.cpu == "visionos_x86_64" or
+        ctx.attr.cpu == "visionos_sim_arm64"
+    ):
         apply_default_compiler_flags_feature = feature(
             name = "apply_default_compiler_flags",
             flag_sets = [
@@ -731,6 +735,8 @@ def _impl(ctx):
                 ),
             ],
         )
+    else:
+        fail("Unreachable")
 
     runtime_root_flags_feature = feature(
         name = "runtime_root_flags",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -15,6 +15,7 @@ objc_library(
         "@platforms//os:ios": [],
         "@platforms//os:macos": [],
         "@platforms//os:tvos": [],
+        "@platforms//os:visionos": [],
         "@platforms//os:watchos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),

--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -15,3 +15,33 @@ def binary_test_suite(name):
         verifier_script = "//test/shell:verify_binary.sh",
         target_under_test = "//test/test_data:apple_binary",
     )
+
+    apple_verification_test(
+        name = "{}_visionos_device_test".format(name),
+        tags = [name],
+        build_type = "device",
+        cpus = {"visionos_cpus": "arm64"},
+        expected_platform_type = "visionos",
+        verifier_script = "//test/shell:verify_binary.sh",
+        target_under_test = "//test/test_data:visionos_binary",
+    )
+
+    apple_verification_test(
+        name = "{}_visionos_arm64_simulator_test".format(name),
+        tags = [name],
+        build_type = "simulator",
+        cpus = {"visionos_cpus": "sim_arm64"},
+        expected_platform_type = "visionos",
+        verifier_script = "//test/shell:verify_binary.sh",
+        target_under_test = "//test/test_data:visionos_binary",
+    )
+
+    apple_verification_test(
+        name = "{}_visionos_x86_64_simulator_test".format(name),
+        tags = [name],
+        build_type = "simulator",
+        cpus = {"visionos_cpus": "x86_64"},
+        expected_platform_type = "visionos",
+        verifier_script = "//test/shell:verify_binary.sh",
+        target_under_test = "//test/test_data:visionos_binary",
+    )

--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -13,7 +13,7 @@ def binary_test_suite(name):
         cpus = {"macos_cpus": "x86_64"},
         expected_platform_type = "macos",
         verifier_script = "//test/shell:verify_binary.sh",
-        target_under_test = "//test/test_data:apple_binary",
+        target_under_test = "//test/test_data:macos_binary",
     )
 
     apple_verification_test(

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -27,7 +27,7 @@ def linking_test_suite(name):
             "-ObjC",
         ],
         mnemonic = "ObjcLink",
-        target_under_test = "//test/test_data:apple_binary",
+        target_under_test = "//test/test_data:macos_binary",
     )
 
     disable_objc_test(
@@ -41,5 +41,5 @@ def linking_test_suite(name):
         ],
         not_expected_argv = ["-ObjC"],
         mnemonic = "ObjcLink",
-        target_under_test = "//test/test_data:apple_binary",
+        target_under_test = "//test/test_data:macos_binary",
     )

--- a/test/rules/apple_verification_test.bzl
+++ b/test/rules/apple_verification_test.bzl
@@ -16,6 +16,8 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
+_supports_visionos = hasattr(apple_common.platform_type, "visionos")
+
 def _transition_impl(_, attr):
     output_dictionary = {
         "//command_line_option:cpu": "darwin_x86_64",
@@ -29,6 +31,7 @@ def _transition_impl(_, attr):
             "//command_line_option:visionos_cpus": "x86_64",
             "//command_line_option:watchos_cpus": "x86_64",
         })
+
     else:
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "arm64",
@@ -42,6 +45,9 @@ def _transition_impl(_, attr):
             command_line_option = "//command_line_option:%s" % cpu_option
             output_dictionary.update({command_line_option: cpu})
 
+    if not _supports_visionos:
+        output_dictionary.pop("//command_line_option:visionos_cpus", None)
+
     return output_dictionary
 
 _transition = transition(
@@ -53,9 +59,8 @@ _transition = transition(
         "//command_line_option:ios_signing_cert_name",
         "//command_line_option:macos_cpus",
         "//command_line_option:tvos_cpus",
-        "//command_line_option:visionos_cpus",
         "//command_line_option:watchos_cpus",
-    ],
+    ] + (["//command_line_option:visionos_cpus"] if _supports_visionos else []),
 )
 
 def _apple_verification_test_impl(ctx):

--- a/test/rules/apple_verification_test.bzl
+++ b/test/rules/apple_verification_test.bzl
@@ -26,12 +26,14 @@ def _transition_impl(_, attr):
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "x86_64",
             "//command_line_option:tvos_cpus": "x86_64",
+            "//command_line_option:visionos_cpus": "x86_64",
             "//command_line_option:watchos_cpus": "x86_64",
         })
     else:
         output_dictionary.update({
             "//command_line_option:ios_multi_cpus": "arm64",
             "//command_line_option:tvos_cpus": "arm64",
+            "//command_line_option:visionos_cpus": "arm64",
             "//command_line_option:watchos_cpus": "arm64_32,armv7k",
         })
 
@@ -51,6 +53,7 @@ _transition = transition(
         "//command_line_option:ios_signing_cert_name",
         "//command_line_option:macos_cpus",
         "//command_line_option:tvos_cpus",
+        "//command_line_option:visionos_cpus",
         "//command_line_option:watchos_cpus",
     ],
 )

--- a/test/shell/verify_binary.sh
+++ b/test/shell/verify_binary.sh
@@ -8,6 +8,10 @@ if [[ "$PLATFORM_TYPE" == "ios" && "$BUILD_TYPE" == "device" ]]; then
   expected_platform="IPHONEOS"
 elif [[ "$PLATFORM_TYPE" == "ios" && "$BUILD_TYPE" == "simulator" ]]; then
   expected_platform="IPHONESIMULATOR"
+elif [[ "$PLATFORM_TYPE" == "visionos" && "$BUILD_TYPE" == "device" ]]; then
+  expected_platform="XROS"
+elif [[ "$PLATFORM_TYPE" == "visionos" && "$BUILD_TYPE" == "simulator" ]]; then
+  expected_platform="XROSSIMULATOR"
 fi
 
 otool_output=$(otool -lv "$binary")

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -39,3 +39,30 @@ starlark_apple_binary(
     tags = TARGETS_UNDER_TEST_TAGS,
     deps = [":cc_main"],
 )
+
+cc_library(
+    name = "cc_lib",
+    srcs = ["lib.cc"],
+    tags = TARGETS_UNDER_TEST_TAGS,
+)
+
+objc_library(
+    name = "objc_lib",
+    srcs = ["lib.m"],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = ["cc_lib"],
+)
+
+objc_library(
+    name = "objc_main",
+    srcs = ["main.m"],
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = ["objc_lib"],
+)
+
+starlark_apple_binary(
+    name = "visionos_binary",
+    platform_type = "visionos",
+    tags = TARGETS_UNDER_TEST_TAGS,
+    deps = [":objc_main"],
+)

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -60,9 +60,26 @@ objc_library(
     deps = ["objc_lib"],
 )
 
+config_setting(
+    name = "compiler_gcc",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "gcc",
+    },
+)
+
+config_setting(
+    name = "supports_visionos",
+    values = {"define": "supports_visionos=1"},
+)
+
 starlark_apple_binary(
     name = "visionos_binary",
+    minimum_os_version = "1.0",
     platform_type = "visionos",
     tags = TARGETS_UNDER_TEST_TAGS,
+    target_compatible_with = select({
+        ":supports_visionos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = [":objc_main"],
 )

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -33,7 +33,7 @@ universal_binary(
 )
 
 starlark_apple_binary(
-    name = "apple_binary",
+    name = "macos_binary",
     minimum_os_version = "13.0",
     platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,

--- a/test/test_data/lib.cc
+++ b/test/test_data/lib.cc
@@ -1,0 +1,3 @@
+int cc_function() {
+  return 2;
+}

--- a/test/test_data/lib.m
+++ b/test/test_data/lib.m
@@ -1,0 +1,3 @@
+int objc_function() {
+    return 1;
+}

--- a/test/test_data/main.m
+++ b/test/test_data/main.m
@@ -1,0 +1,3 @@
+int main() {
+    return 42;
+}

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -4,6 +4,7 @@ _PLATFORM_TYPE_TO_CPUS_FLAG = {
     "ios": "//command_line_option:ios_multi_cpus",
     "macos": "//command_line_option:macos_cpus",
     "tvos": "//command_line_option:tvos_cpus",
+    "visionos": "//command_line_option:visionos_cpus",
     "watchos": "//command_line_option:watchos_cpus",
 }
 
@@ -11,8 +12,11 @@ _PLATFORM_TYPE_TO_DEFAULT_ARCH = {
     "ios": "x86_64",
     "macos": "x86_64",
     "tvos": "x86_64",
+    "visionos": "x86_64",
     "watchos": "i386",
 }
+
+_supports_visionos = hasattr(apple_common.platform_type, "visionos")
 
 def _cpu_string(*, environment_arch, platform_type, settings = {}):
     if platform_type == "ios":
@@ -51,6 +55,13 @@ def _cpu_string(*, environment_arch, platform_type, settings = {}):
         if watchos_cpus:
             return "watchos_{}".format(watchos_cpus[0])
         return "watchos_i386"
+    if platform_type == "visionos":
+        if environment_arch:
+            return "visionos_{}".format(environment_arch)
+        visionos_cpus = settings["//command_line_option:visionos_cpus"]
+        if visionos_cpus:
+            return "visionos_{}".format(visionos_cpus[0])
+        return "visionos_x86_64"
 
     fail("ERROR: Unknown platform type: {}".format(platform_type))
 
@@ -104,16 +115,17 @@ def _command_line_options(*, apple_platforms = [], environment_arch = None, mini
     return output_dictionary
 
 _apple_platform_transition_inputs = [
+    "//command_line_option:apple_crosstool_top",
     "//command_line_option:apple_platforms",
     "//command_line_option:cpu",
-    "//command_line_option:apple_crosstool_top",
+    "//command_line_option:incompatible_enable_apple_toolchain_resolution",
     "//command_line_option:ios_multi_cpus",
     "//command_line_option:macos_cpus",
+    "//command_line_option:platforms",
     "//command_line_option:tvos_cpus",
     "//command_line_option:watchos_cpus",
-    "//command_line_option:incompatible_enable_apple_toolchain_resolution",
-    "//command_line_option:platforms",
-]
+] + (["//command_line_option:visionos_cpus"] if _supports_visionos else [])
+
 _apple_rule_base_transition_outputs = [
     "//command_line_option:apple configuration distinguisher",
     "//command_line_option:apple_platform_type",


### PR DESCRIPTION
Depends on https://github.com/bazelbuild/bazel/pull/18905 and https://github.com/bazelbuild/platforms/pull/71
