### PR TITLE
Add ~/Applications to allowed include directories

### DIFF
--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -38,7 +38,10 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, xcode_toolchains):
 
     user = repository_ctx.os.environ.get("USER")
     if user:
-        include_dirs.append("/Users/{}/Library/".format(user))
+        include_dirs.extend([
+            "/Users/{}/Applications/".format(user),
+            "/Users/{}/Library/".format(user),
+        ])
 
     # Include extra Xcode paths in case they're installed on other volumes
     for toolchain in xcode_toolchains:


### PR DESCRIPTION
Assume that if this directory matters for this it's because the user has
installed Xcode into ~/Applications. If you need anything outside of
these defaults otherwise you have to use
`BAZEL_ALLOW_NON_APPLICATIONS_XCODE` as mentioned in the readme.
