### PR TITLE
Move starlark_apple_static_library into bzl file

### DIFF
--- a/test/shell/BUILD
+++ b/test/shell/BUILD
@@ -22,19 +22,12 @@ sh_library(
     ],
 )
 
-sh_library(
-    name = "apple_common",
-    testonly = True,
-    srcs = ["apple_common.sh"],
-)
-
 sh_test(
     name = "objc_test",
     size = "large",
     srcs = ["objc_test.sh"],
     data = [":for_bazel_tests"],
     deps = [
-        ":apple_common",
         ":bashunit",
     ],
 )
@@ -45,7 +38,6 @@ sh_test(
     data = [":for_bazel_tests"],
     shard_count = 3,
     deps = [
-        ":apple_common",
         ":bashunit",
     ],
 )

--- a/test/shell/apple_test.sh
+++ b/test/shell/apple_test.sh
@@ -120,13 +120,9 @@ EOF
 function test_apple_static_library() {
   rm -rf package
   mkdir -p package
-  make_starlark_apple_static_library_rule_in package
 
   cat > package/BUILD <<EOF
-load(
-    "//package:starlark_apple_static_library.bzl",
-    "starlark_apple_static_library",
-)
+load("@build_bazel_apple_support//test:starlark_apple_static_library.bzl", "starlark_apple_static_library")
 starlark_apple_static_library(
     name = "static_lib",
     deps = [":dummy_lib"],

--- a/test/shell/integration_test_setup.sh
+++ b/test/shell/integration_test_setup.sh
@@ -23,5 +23,3 @@ source "$(rlocation build_bazel_apple_support/test/shell/unittest.bash)" \
   || print_message_and_exit "unittest.bash not found!"
 source "$(rlocation build_bazel_apple_support/test/shell/testenv.sh)" \
   || print_message_and_exit "testenv.sh not found!"
-source "$(rlocation build_bazel_apple_support/test/shell/apple_common.sh)" \
-  || print_message_and_exit "apple_common.sh not found!"

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -81,9 +81,6 @@ starlark_apple_static_library = rule(
         "platform_type": attr.string(),
         "minimum_os_version": attr.string(),
     },
-    outputs = {
-        "lipo_archive": "%{name}_lipo.a",
-    },
     cfg = apple_common.apple_crosstool_transition,
     fragments = ["apple", "objc", "cpp"],
 )


### PR DESCRIPTION
No reason to complicate the shell tests with generating this test rule
