### PR TITLE
Remove -lc++ from non-C++ binary link actions

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1585,7 +1585,12 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    _OBJCPP_EXECUTABLE_ACTION_NAME,
+                ],
                 flag_groups = [flag_group(flags = ["-lc++"])],
                 with_features = [with_feature_set(not_features = ["kernel_extension"])],
             ),


### PR DESCRIPTION
In the case you're linking an ObjC binary, we shouldn't add `-lc++` by
default, but users can still add this in their `sdk_dylibs` if they'd
like.
