### PR TITLE
Remove -lc++ from crosstool

### DIFF
--- a/crosstool/BUILD
+++ b/crosstool/BUILD
@@ -12,6 +12,7 @@ cc_binary(
         "wrapped_clang.cc",
     ],
     copts = ["-std=c++17"],
+    linkopts = ["-lc++"],
 )
 
 # Consumed by bazel tests.

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1580,18 +1580,6 @@ def _impl(ctx):
         provides = ["profile"],
     )
 
-    link_libcpp_feature = feature(
-        name = "link_libc++",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
-                flag_groups = [flag_group(flags = ["-lc++"])],
-                with_features = [with_feature_set(not_features = ["kernel_extension"])],
-            ),
-        ],
-    )
-
     objc_actions_feature = feature(
         name = "objc_actions",
         implies = [
@@ -2436,7 +2424,6 @@ def _impl(ctx):
         feature(name = "opt"),
 
         # Features with more configuration
-        link_libcpp_feature,
         default_compile_flags_feature,
         debug_prefix_map_pwd_is_dot_feature,
         remap_xcode_path_feature,

--- a/test/shell/objc_test.sh
+++ b/test/shell/objc_test.sh
@@ -167,6 +167,7 @@ objc_library(
 cc_test(
     name = "d",
     deps = [":b"],
+    linkopts = ["-lc++"],
 )
 EOF
 

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -17,12 +17,14 @@ TARGETS_UNDER_TEST_TAGS = [
 cc_binary(
     name = "cc_test_binary",
     srcs = ["main.cc"],
+    linkopts = ["-lc++"],
     tags = TARGETS_UNDER_TEST_TAGS,
 )
 
 cc_library(
     name = "cc_main",
     srcs = ["main.cc"],
+    linkopts = ["-lc++"],
     tags = TARGETS_UNDER_TEST_TAGS,
 )
 


### PR DESCRIPTION
As of Xcode 15 ld-prime warns about duplicate `-lfoo` flags. This
default flag results in a duplicate if anything in your dependency tree
sets `linkopts = ["-lc++"]` or `sdk_dylibs = ["c++"]`. Currently there
is no way for a crosstool to automatically add this flag and avoid this
duplication warning.
