### PR TITLE
Remove //test:for_bazel_test from global for_bazel_tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,7 +29,6 @@ filegroup(
         "//crosstool:for_bazel_tests",
         "//lib:for_bazel_tests",
         "//rules:for_bazel_tests",
-        "//test:for_bazel_tests",
         "//tools:for_bazel_tests",
     ],
     # Exposed publicly just so other rules can use this if they set up

--- a/test/BUILD
+++ b/test/BUILD
@@ -79,7 +79,7 @@ filegroup(
     name = "for_bazel_tests",
     testonly = True,
     srcs = glob(["**"]),
-    visibility = ["//:__pkg__"],
+    visibility = ["//test/shell:__pkg__"],
 )
 
 cc_binary(

--- a/test/shell/BUILD
+++ b/test/shell/BUILD
@@ -4,6 +4,7 @@ filegroup(
     name = "for_bazel_tests",
     testonly = True,
     srcs = [
+        "//test:for_bazel_tests",
         "@build_bazel_apple_support//:for_bazel_tests",
     ],
 )


### PR DESCRIPTION
If the test/ package is invalid we still shouldn't fail rules_apple.
This can happen when bazel deletes an API that we use only in tests in
this repo
