### PR TITLE
Add platforms to default repositories.bzl

### DIFF
--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -46,4 +46,14 @@ def apple_support_dependencies():
         sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
     )
 
+    _maybe(
+        http_archive,
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+        ],
+        sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
+    )
+
     apple_cc_configure()


### PR DESCRIPTION
If nothing loads this then it comes from bazel itself so the version
depends on your version of bazel, we want a newer one to support
visionOS.
