### PR TITLE
Remove apple_common transitions

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -46,7 +46,7 @@ tasks:
 
   macos_last_green:
     name: "Last Green Bazel"
-    bazel: d9939570353e21ba4d8b8e986b30b753a0f29c5d
+    bazel: last_green
     <<: *common
 
   macos_latest_head_deps:
@@ -66,7 +66,7 @@ tasks:
 
   macos_last_green_vendored_toolchain:
     name: "Last Green Bazel vendored toolchain"
-    bazel: d9939570353e21ba4d8b8e986b30b753a0f29c5d
+    bazel: last_green
     <<: *common
     <<: *toolchain_flags
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -99,5 +99,7 @@ objc_library(
 
 starlark_apple_binary(
     name = "main_apple",
+    minimum_os_version = "13.0",
+    platform_type = "macos",
     deps = ["main_objc"],
 )

--- a/test/shell/apple_test.sh
+++ b/test/shell/apple_test.sh
@@ -53,6 +53,7 @@ starlark_apple_binary(
     name = "main_binary",
     deps = [":main_lib"],
     platform_type = "watchos",
+    minimum_os_version = '8.0',
 )
 objc_library(
     name = "main_lib",

--- a/test/shell/objc_test.sh
+++ b/test/shell/objc_test.sh
@@ -120,6 +120,7 @@ EOF
 load("@build_bazel_apple_support//test:starlark_apple_binary.bzl", "starlark_apple_binary")
 starlark_apple_binary(name = 'app',
                       deps = [':main'],
+                      minimum_os_version = '13.0',
                       platform_type = 'ios')
 objc_library(name = 'main',
              non_arc_srcs = ['main.m'])

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -1,5 +1,7 @@
 """Test rule for linking with bazel's builtin Apple logic"""
 
+load("//test:transitions.bzl", "apple_platform_split_transition")
+
 def _starlark_apple_binary_impl(ctx):
     link_result = apple_common.link_multi_arch_binary(
         ctx = ctx,
@@ -49,7 +51,7 @@ def _starlark_apple_binary_impl(ctx):
 starlark_apple_binary = rule(
     attrs = {
         "_child_configuration_dummy": attr.label(
-            cfg = apple_common.multi_arch_split,
+            cfg = apple_platform_split_transition,
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "_xcode_config": attr.label(
@@ -66,13 +68,16 @@ starlark_apple_binary = rule(
         "binary_type": attr.string(default = "executable"),
         "bundle_loader": attr.label(),
         "deps": attr.label_list(
-            cfg = apple_common.multi_arch_split,
+            cfg = apple_platform_split_transition,
         ),
         "dylibs": attr.label_list(),
         "linkopts": attr.string_list(),
-        "minimum_os_version": attr.string(),
-        "platform_type": attr.string(),
+        "minimum_os_version": attr.string(mandatory = True),
+        "platform_type": attr.string(mandatory = True),
         "stamp": attr.int(default = -1, values = [-1, 0, 1]),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
     fragments = ["apple", "objc", "cpp"],
     implementation = _starlark_apple_binary_impl,

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -1,5 +1,7 @@
 """Test rule for static linking with bazel's builtin Apple logic"""
 
+load("//test:transitions.bzl", "apple_platform_split_transition")
+
 def _starlark_apple_static_library_impl(ctx):
     if not hasattr(apple_common.platform_type, ctx.attr.platform_type):
         fail('Unsupported platform type \"{}\"'.format(ctx.attr.platform_type))
@@ -53,7 +55,7 @@ starlark_apple_static_library = rule(
     _starlark_apple_static_library_impl,
     attrs = {
         "_child_configuration_dummy": attr.label(
-            cfg = apple_common.multi_arch_split,
+            cfg = apple_platform_split_transition,
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
         ),
         "_xcode_config": attr.label(
@@ -71,16 +73,18 @@ starlark_apple_static_library = rule(
             allow_files = True,
         ),
         "avoid_deps": attr.label_list(
-            cfg = apple_common.multi_arch_split,
+            cfg = apple_platform_split_transition,
             default = [],
         ),
         "deps": attr.label_list(
-            cfg = apple_common.multi_arch_split,
+            cfg = apple_platform_split_transition,
         ),
         "linkopts": attr.string_list(),
-        "platform_type": attr.string(),
-        "minimum_os_version": attr.string(),
+        "platform_type": attr.string(mandatory = True),
+        "minimum_os_version": attr.string(mandatory = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
     },
-    cfg = apple_common.apple_crosstool_transition,
     fragments = ["apple", "objc", "cpp"],
 )

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -34,6 +34,7 @@ universal_binary(
 
 starlark_apple_binary(
     name = "apple_binary",
+    minimum_os_version = "13.0",
     platform_type = "macos",
     tags = TARGETS_UNDER_TEST_TAGS,
     deps = [":cc_main"],

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -1,0 +1,189 @@
+"""Dummy transitions for testing basic behavior"""
+
+_PLATFORM_TYPE_TO_CPUS_FLAG = {
+    "ios": "//command_line_option:ios_multi_cpus",
+    "macos": "//command_line_option:macos_cpus",
+    "tvos": "//command_line_option:tvos_cpus",
+    "watchos": "//command_line_option:watchos_cpus",
+}
+
+_PLATFORM_TYPE_TO_DEFAULT_ARCH = {
+    "ios": "x86_64",
+    "macos": "x86_64",
+    "tvos": "x86_64",
+    "watchos": "i386",
+}
+
+def _cpu_string(*, environment_arch, platform_type, settings = {}):
+    if platform_type == "ios":
+        if environment_arch:
+            return "ios_{}".format(environment_arch)
+        ios_cpus = settings["//command_line_option:ios_multi_cpus"]
+        if ios_cpus:
+            return "ios_{}".format(ios_cpus[0])
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith("ios_"):
+            return cpu_value
+        if cpu_value == "darwin_arm64":
+            return "ios_sim_arm64"
+        return "ios_x86_64"
+    if platform_type == "macos":
+        if environment_arch:
+            return "darwin_{}".format(environment_arch)
+        macos_cpus = settings["//command_line_option:macos_cpus"]
+        if macos_cpus:
+            return "darwin_{}".format(macos_cpus[0])
+        cpu_value = settings["//command_line_option:cpu"]
+        if cpu_value.startswith("darwin_"):
+            return cpu_value
+        return "darwin_x86_64"
+    if platform_type == "tvos":
+        if environment_arch:
+            return "tvos_{}".format(environment_arch)
+        tvos_cpus = settings["//command_line_option:tvos_cpus"]
+        if tvos_cpus:
+            return "tvos_{}".format(tvos_cpus[0])
+        return "tvos_x86_64"
+    if platform_type == "watchos":
+        if environment_arch:
+            return "watchos_{}".format(environment_arch)
+        watchos_cpus = settings["//command_line_option:watchos_cpus"]
+        if watchos_cpus:
+            return "watchos_{}".format(watchos_cpus[0])
+        return "watchos_i386"
+
+    fail("ERROR: Unknown platform type: {}".format(platform_type))
+
+def _min_os_version_or_none(*, minimum_os_version, platform, platform_type):
+    if platform_type == platform:
+        return minimum_os_version
+    return None
+
+def _command_line_options(*, apple_platforms = [], environment_arch = None, minimum_os_version, platform_type, settings):
+    output_dictionary = {
+        "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,
+        "//command_line_option:apple_platform_type": platform_type,
+        "//command_line_option:apple_platforms": apple_platforms,
+        # `apple_split_cpu` is used by the Bazel Apple configuration distinguisher to distinguish
+        # architecture and environment, therefore we set `environment_arch` when it is available.
+        "//command_line_option:apple_split_cpu": environment_arch if environment_arch else "",
+        "//command_line_option:compiler": None,
+        "//command_line_option:cpu": _cpu_string(
+            environment_arch = environment_arch,
+            platform_type = platform_type,
+            settings = settings,
+        ),
+        "//command_line_option:crosstool_top": (
+            settings["//command_line_option:apple_crosstool_top"]
+        ),
+        "//command_line_option:fission": [],
+        "//command_line_option:grte_top": None,
+        "//command_line_option:platforms": [apple_platforms[0]] if apple_platforms else [],
+        "//command_line_option:ios_minimum_os": _min_os_version_or_none(
+            minimum_os_version = minimum_os_version,
+            platform = "ios",
+            platform_type = platform_type,
+        ),
+        "//command_line_option:macos_minimum_os": _min_os_version_or_none(
+            minimum_os_version = minimum_os_version,
+            platform = "macos",
+            platform_type = platform_type,
+        ),
+        "//command_line_option:tvos_minimum_os": _min_os_version_or_none(
+            minimum_os_version = minimum_os_version,
+            platform = "tvos",
+            platform_type = platform_type,
+        ),
+        "//command_line_option:watchos_minimum_os": _min_os_version_or_none(
+            minimum_os_version = minimum_os_version,
+            platform = "watchos",
+            platform_type = platform_type,
+        ),
+    }
+
+    return output_dictionary
+
+_apple_platform_transition_inputs = [
+    "//command_line_option:apple_platforms",
+    "//command_line_option:cpu",
+    "//command_line_option:apple_crosstool_top",
+    "//command_line_option:ios_multi_cpus",
+    "//command_line_option:macos_cpus",
+    "//command_line_option:tvos_cpus",
+    "//command_line_option:watchos_cpus",
+    "//command_line_option:incompatible_enable_apple_toolchain_resolution",
+    "//command_line_option:platforms",
+]
+_apple_rule_base_transition_outputs = [
+    "//command_line_option:apple configuration distinguisher",
+    "//command_line_option:apple_platform_type",
+    "//command_line_option:apple_platforms",
+    "//command_line_option:apple_split_cpu",
+    "//command_line_option:compiler",
+    "//command_line_option:cpu",
+    "//command_line_option:crosstool_top",
+    "//command_line_option:fission",
+    "//command_line_option:grte_top",
+    "//command_line_option:ios_minimum_os",
+    "//command_line_option:macos_minimum_os",
+    "//command_line_option:platforms",
+    "//command_line_option:tvos_minimum_os",
+    "//command_line_option:watchos_minimum_os",
+]
+
+def _apple_platform_split_transition_impl(settings, attr):
+    output_dictionary = {}
+    if settings["//command_line_option:incompatible_enable_apple_toolchain_resolution"]:
+        platforms = (
+            settings["//command_line_option:apple_platforms"] or
+            settings["//command_line_option:platforms"]
+        )
+        # Currently there is no "default" platform for Apple-based platforms. If necessary, a
+        # default platform could be generated for the rule's underlying platform_type, but for now
+        # we work with the assumption that all users of the rules should set an appropriate set of
+        # platforms when building Apple targets with `apple_platforms`.
+
+        for index, platform in enumerate(platforms):
+            # Create a new, reordered list so that the platform we need to resolve is always first,
+            # and the other platforms will follow.
+            apple_platforms = list(platforms)
+            platform_to_resolve = apple_platforms.pop(index)
+            apple_platforms.insert(0, platform_to_resolve)
+
+            if str(platform) not in output_dictionary:
+                output_dictionary[str(platform)] = _command_line_options(
+                    apple_platforms = apple_platforms,
+                    minimum_os_version = attr.minimum_os_version,
+                    platform_type = attr.platform_type,
+                    settings = settings,
+                )
+
+    else:
+        platform_type = attr.platform_type
+        environment_archs = settings[_PLATFORM_TYPE_TO_CPUS_FLAG[platform_type]]
+        if not environment_archs:
+            environment_archs = [_PLATFORM_TYPE_TO_DEFAULT_ARCH[platform_type]]
+        for environment_arch in environment_archs:
+            found_cpu = _cpu_string(
+                environment_arch = environment_arch,
+                platform_type = platform_type,
+                settings = settings,
+            )
+            if found_cpu in output_dictionary:
+                continue
+
+            minimum_os_version = attr.minimum_os_version
+            output_dictionary[found_cpu] = _command_line_options(
+                environment_arch = environment_arch,
+                minimum_os_version = minimum_os_version,
+                platform_type = platform_type,
+                settings = settings,
+            )
+
+    return output_dictionary
+
+apple_platform_split_transition = transition(
+    implementation = _apple_platform_split_transition_impl,
+    inputs = _apple_platform_transition_inputs,
+    outputs = _apple_rule_base_transition_outputs,
+)


### PR DESCRIPTION
This was removed upstream but we still need the smallest possible
transition for testing, this copies the one from rules_apple and removes
a bunch of the features. If this ends up being too much of a pain to
update we'll have to find a different solution.
