### PR TITLE
Fix ios_arm64e cpu value to match platforms cpu constraint

### DIFF
--- a/configs/platforms.bzl
+++ b/configs/platforms.bzl
@@ -23,7 +23,7 @@ APPLE_PLATFORMS_CONSTRAINTS = {
     ],
     "ios_arm64e": [
         "@platforms//os:ios",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:arm64e",
         "@build_bazel_apple_support//constraints:device",
     ],
     "ios_x86_64": [


### PR DESCRIPTION
This fixes so that rules_apple work with C++ toolchain resolution enabled.

Failure example: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1638#018a6805-45af-4dcc-a83b-3f3f3231713c

Tested manually.