### PR TITLE
Enable use_default_shell_env everywhere

### DIFF
--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -23,6 +23,10 @@ _XCODE_PATH_RESOLVE_LEVEL = struct(
     args_and_files = "args_and_files",
 )
 
+# This is a proxy for being on bazel 7.x which has
+# --incompatible_merge_fixed_and_default_shell_env enabled by default
+_USE_DEFAULT_SHELL_ENV = not hasattr(apple_common, "apple_crosstool_transition")
+
 _XCODE_PROCESSOR__ARGS = r"""#!/bin/bash
 
 set -eu
@@ -188,6 +192,9 @@ def _kwargs_for_apple_platform(
     original_env = processed_args.get("env")
     if original_env:
         merged_env.update(original_env)
+
+    if "use_default_shell_env" not in processed_args:
+        processed_args["use_default_shell_env"] = _USE_DEFAULT_SHELL_ENV
 
     # Add the environment variables required for DEVELOPER_DIR and SDKROOT last to avoid clients
     # overriding these values.


### PR DESCRIPTION
Now that bazel 7.x has
https://bazel.build/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env
enabled by default, we can set `use_default_shell_env = True` moving
forward. This makes actions respect `--action_env=FOO` which can be
useful for things like `TOOLCHAINS`, `ZERO_AR_DATE`, `TMPDIR`, etc.
Previously these were ignored.
