### PR TITLE
Add build flags to allow overriding platforms used in transitions

### DIFF
--- a/configs/platforms.bzl
+++ b/configs/platforms.bzl
@@ -87,3 +87,23 @@ APPLE_PLATFORMS_CONSTRAINTS = {
         "@build_bazel_apple_support//constraints:simulator",
     ],
 }
+
+CPU_TO_DEFAULT_PLATFORM_NAME = {
+    "darwin_arm64": "macos_arm64",
+    "darwin_arm64e": "macos_arm64e",
+    "darwin_x86_64": "macos_x86_64",
+    "ios_arm64": "ios_arm64",
+    "ios_arm64e": "ios_arm64e",
+    "ios_x86_64": "ios_x86_64",
+    "ios_sim_arm64": "ios_sim_arm64",
+    "tvos_arm64": "tvos_arm64",
+    "tvos_x86_64": "tvos_x86_64",
+    "tvos_sim_arm64": "tvos_sim_arm64",
+    "visionos_arm64": "visionos_arm64",
+    "visionos_sim_arm64": "visionos_sim_arm64",
+    "visionos_x86_64": "visionos_x86_64",
+    "watchos_arm64": "watchos_arm64",
+    "watchos_arm64_32": "watchos_arm64_32",
+    "watchos_armv7k": "watchos_armv7k",
+    "watchos_x86_64": "watchos_x86_64",
+}

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -21,13 +21,13 @@ def _macos_universal_transition_impl(settings, _attr):
             {
                 "//command_line_option:cpu": "darwin_arm64",
                 "//command_line_option:platforms": [
-                    settings["//platforms:default_macos_arm64"],
+                    settings["//platforms:macos_arm64_platform"],
                 ],
             },
             {
                 "//command_line_option:cpu": "darwin_x86_64",
                 "//command_line_option:platforms": [
-                    settings["//platforms:default_macos_x86_64"],
+                    settings["//platforms:macos_x86_64_platform"],
                 ],
             },
         ]
@@ -39,8 +39,8 @@ macos_universal_transition = transition(
     inputs = [
         "//command_line_option:cpu",
         "//command_line_option:platforms",
-        "//platforms:default_macos_x86_64",
-        "//platforms:default_macos_arm64",
+        "//platforms:macos_x86_64_platform",
+        "//platforms:macos_arm64_platform",
     ],
     outputs = ["//command_line_option:cpu", "//command_line_option:platforms"],
 )

--- a/lib/transitions.bzl
+++ b/lib/transitions.bzl
@@ -20,11 +20,15 @@ def _macos_universal_transition_impl(settings, _attr):
         return [
             {
                 "//command_line_option:cpu": "darwin_arm64",
-                "//command_line_option:platforms": "//platforms:macos_arm64",
+                "//command_line_option:platforms": [
+                    settings["//platforms:default_macos_arm64"],
+                ],
             },
             {
                 "//command_line_option:cpu": "darwin_x86_64",
-                "//command_line_option:platforms": "//platforms:macos_x86_64",
+                "//command_line_option:platforms": [
+                    settings["//platforms:default_macos_x86_64"],
+                ],
             },
         ]
     else:
@@ -32,6 +36,11 @@ def _macos_universal_transition_impl(settings, _attr):
 
 macos_universal_transition = transition(
     implementation = _macos_universal_transition_impl,
-    inputs = ["//command_line_option:cpu", "//command_line_option:platforms"],
+    inputs = [
+        "//command_line_option:cpu",
+        "//command_line_option:platforms",
+        "//platforms:default_macos_x86_64",
+        "//platforms:default_macos_arm64",
+    ],
     outputs = ["//command_line_option:cpu", "//command_line_option:platforms"],
 )

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -31,7 +31,7 @@ alias(
 
 [
     label_flag(
-        name = "default_" + platform,
+        name = platform + "_platform",
         build_setting_default = platform,
     )
     for platform in CPU_TO_DEFAULT_PLATFORM_NAME.values()

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -1,4 +1,8 @@
-load("//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
+load(
+    "//configs:platforms.bzl",
+    "APPLE_PLATFORMS_CONSTRAINTS",
+    "CPU_TO_DEFAULT_PLATFORM_NAME",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -19,6 +23,19 @@ alias(
     name = "macos_arm64",
     actual = "darwin_arm64",
 )
+
+alias(
+    name = "macos_arm64e",
+    actual = "darwin_arm64e",
+)
+
+[
+    label_flag(
+        name = "default_" + platform,
+        build_setting_default = platform,
+    )
+    for platform in CPU_TO_DEFAULT_PLATFORM_NAME.values()
+]
 
 # Consumed by bazel tests.
 filegroup(

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -1,5 +1,7 @@
 """Dummy transitions for testing basic behavior"""
 
+load("//configs:platforms.bzl", "CPU_TO_DEFAULT_PLATFORM_NAME")
+
 _PLATFORM_TYPE_TO_CPUS_FLAG = {
     "ios": "//command_line_option:ios_multi_cpus",
     "macos": "//command_line_option:macos_cpus",
@@ -16,25 +18,9 @@ _PLATFORM_TYPE_TO_DEFAULT_ARCH = {
     "watchos": "x86_64",
 }
 
-_CPU_TO_PLATFORM = {
-    "darwin_x86_64": "//platforms:macos_x86_64",
-    "darwin_arm64": "//platforms:macos_arm64",
-    "darwin_arm64e": "//platforms:darwin_arm64e",
-    "ios_x86_64": "//platforms:ios_x86_64",
-    "ios_arm64": "//platforms:ios_arm64",
-    "ios_sim_arm64": "//platforms:ios_sim_arm64",
-    "ios_arm64e": "//platforms:ios_arm64e",
-    "tvos_sim_arm64": "//platforms:tvos_sim_arm64",
-    "tvos_arm64": "//platforms:tvos_arm64",
-    "tvos_x86_64": "//platforms:tvos_x86_64",
-    "visionos_arm64": "//platforms:visionos_arm64",
-    "visionos_sim_arm64": "//platforms:visionos_sim_arm64",
-    "visionos_x86_64": "//platforms/simulator:visionos_x86_64",
-    "watchos_armv7k": "//platforms:watchos_armv7k",
-    "watchos_arm64": "//platforms:watchos_arm64",
-    "watchos_device_arm64": "//platforms:watchos_arm64",
-    "watchos_arm64_32": "//platforms:watchos_arm64_32",
-    "watchos_x86_64": "//platforms:watchos_x86_64",
+_CPU_TO_DEFAULT_PLATFORM_FLAG = {
+    cpu: "//platforms:default_" + platform_name
+    for cpu, platform_name in CPU_TO_DEFAULT_PLATFORM_NAME.items()
 }
 
 _supports_visionos = hasattr(apple_common.platform_type, "visionos")
@@ -112,7 +98,9 @@ def _command_line_options(*, apple_platforms = [], environment_arch = None, mini
         ),
         "//command_line_option:fission": [],
         "//command_line_option:grte_top": None,
-        "//command_line_option:platforms": [apple_platforms[0]] if apple_platforms else [_CPU_TO_PLATFORM[cpu]],
+        "//command_line_option:platforms": (
+            [apple_platforms[0]] if apple_platforms else [settings[_CPU_TO_DEFAULT_PLATFORM_FLAG[cpu]]]
+        ),
         "//command_line_option:ios_minimum_os": _min_os_version_or_none(
             minimum_os_version = minimum_os_version,
             platform = "ios",
@@ -147,7 +135,9 @@ _apple_platform_transition_inputs = [
     "//command_line_option:platforms",
     "//command_line_option:tvos_cpus",
     "//command_line_option:watchos_cpus",
-] + (["//command_line_option:visionos_cpus"] if _supports_visionos else [])
+] + (
+    _CPU_TO_DEFAULT_PLATFORM_FLAG.values()
+) + (["//command_line_option:visionos_cpus"] if _supports_visionos else [])
 
 _apple_rule_base_transition_outputs = [
     "//command_line_option:apple configuration distinguisher",

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -19,7 +19,7 @@ _PLATFORM_TYPE_TO_DEFAULT_ARCH = {
 }
 
 _CPU_TO_DEFAULT_PLATFORM_FLAG = {
-    cpu: "//platforms:default_" + platform_name
+    cpu: "//platforms:{}_platform".format(platform_name)
     for cpu, platform_name in CPU_TO_DEFAULT_PLATFORM_NAME.items()
 }
 

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -135,9 +135,9 @@ _apple_platform_transition_inputs = [
     "//command_line_option:platforms",
     "//command_line_option:tvos_cpus",
     "//command_line_option:watchos_cpus",
-] + (
-    _CPU_TO_DEFAULT_PLATFORM_FLAG.values()
-) + (["//command_line_option:visionos_cpus"] if _supports_visionos else [])
+] + _CPU_TO_DEFAULT_PLATFORM_FLAG.values() + (
+    ["//command_line_option:visionos_cpus"] if _supports_visionos else []
+)
 
 _apple_rule_base_transition_outputs = [
     "//command_line_option:apple configuration distinguisher",


### PR DESCRIPTION
This allows people to use custom versions of the platforms, including child platforms of the default ones, which allows for custom additional constraints and platform properties.