### PR TITLE
Disable `--features=treat_warnings_as_errors` on CI for Bazel 6

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -20,6 +20,14 @@ tasks:
     name: "Latest Bazel"
     bazel: latest
     <<: *common
+    build_flags:
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
+    test_flags:
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
 
   macos_latest_bzlmod:
     name: "Current LTS using bzlmod"
@@ -35,8 +43,14 @@ tasks:
       - "-//doc/..."
     build_flags:
       - "--enable_bzlmod"
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
     test_flags:
       - "--enable_bzlmod"
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
 
   macos_last_green:
     name: "Last Green Bazel"
@@ -51,6 +65,14 @@ tasks:
       # has landed on them breaking this project.
       - .bazelci/update_workspace_to_deps_heads.sh
     <<: *common
+    build_flags:
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
+    test_flags:
+      # Bazel 6.x has dependencies that produce warnings now
+      # TODO: Remove once latest is Bazel 7+
+      - "--features=-treat_warnings_as_errors"
 
   linux_latest:
     name: "Current LTS on Linux"


### PR DESCRIPTION
Bazel 6.x has dependencies that produce warnings now.