### PR TITLE
Ignore MODULE.bazel.lock (#1130)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+/MODULE.bazel.lock


### PR DESCRIPTION
This file is generated by default by bazel @ HEAD but we don't really
want to manage it. This way it can be generated locally and folks can
build offline if they have generated it at least once.
