### PR TITLE
Add environ to repository rule

### DIFF
--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -45,6 +45,7 @@ def _apple_cc_autoconf_impl(repository_ctx):
 _apple_cc_autoconf = repository_rule(
     environ = [
         _DISABLE_ENV_VAR,
+        "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
         "DEVELOPER_DIR",  # Used for making sure we use the right Xcode for compiling toolchain binaries
         "GCOV",  # TODO: Remove this
         "USE_CLANG_CL",  # Kept as a hack for those who rely on this invaliding the toolchain


### PR DESCRIPTION
Currently if you change this env var's value then re-run your build, the repository rule won't re-trigger so you'll get stale results.

Instead, make the repository rule re-trigger if the env var changes.