### PR TITLE
Only enable linkmap if the variable exists

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2295,6 +2295,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                             "-Xlinker",
                             "%{linkmap_exec_path}",
                         ],
+                        expand_if_available = "linkmap_exec_path",
                     ),
                 ],
             ),


### PR DESCRIPTION
In rules_apple we've started using cc_common.link in 1 place, which
doesn't set this variable in bazel since this is an Apple specific
feature in bazel. This means if you try to link a intents stub binary
and pass `--objc_generate_linkmap` the link will fail. We don't care
about generating linkmaps for that binary anyways since it's just an
intermediate artifact, so this fixes that link. This has the downside
that this could hide issues and silently not create linkmaps for links
that should support them in the future.
