### PR TITLE
Replace -l: with path to library

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1343,12 +1343,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                             flag_group(
                                 flag_groups = [
                                     flag_group(
-                                        flags = ["-l:%{libraries_to_link.name}"],
-                                        expand_if_false = "libraries_to_link.is_whole_archive",
-                                    ),
-                                    flag_group(
-                                        flags = ["-Wl,-force_load,-l:%{libraries_to_link.name}"],
-                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                        flags = ["%{libraries_to_link.path}"],
                                     ),
                                 ],
                                 expand_if_equal = variable_with_value(


### PR DESCRIPTION
Mirrors https://github.com/bazelbuild/bazel/pull/20847

This variable isn't supported until the linked change, but if anyone
hit this codepath today it wouldn't work either so it's safe to use
since it just changes the error message to something else.
