### PR TITLE
Remove visionos_x86_64 support

### DIFF
--- a/configs/platforms.bzl
+++ b/configs/platforms.bzl
@@ -73,12 +73,6 @@ APPLE_PLATFORMS_CONSTRAINTS = {
         "@build_bazel_apple_support//constraints:apple",
         "@build_bazel_apple_support//constraints:simulator",
     ],
-    "visionos_x86_64": [
-        "@platforms//os:visionos",
-        "@platforms//cpu:x86_64",
-        "@build_bazel_apple_support//constraints:apple",
-        "@build_bazel_apple_support//constraints:simulator",
-    ],
     "watchos_arm64": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64",
@@ -118,7 +112,6 @@ CPU_TO_DEFAULT_PLATFORM_NAME = {
     "tvos_sim_arm64": "tvos_sim_arm64",
     "visionos_arm64": "visionos_arm64",
     "visionos_sim_arm64": "visionos_sim_arm64",
-    "visionos_x86_64": "visionos_x86_64",
     "watchos_arm64": "watchos_arm64",
     "watchos_arm64_32": "watchos_arm64_32",
     "watchos_armv7k": "watchos_armv7k",

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -99,8 +99,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         target_system_name = "arm64e-apple-macosx{}".format(target_os_version)
     elif (ctx.attr.cpu == "tvos_x86_64"):
         target_system_name = "x86_64-apple-tvos{}-simulator".format(target_os_version)
-    elif (ctx.attr.cpu == "visionos_x86_64"):
-        target_system_name = "x86_64-apple-xros{}-simulator".format(target_os_version)
     elif (ctx.attr.cpu == "watchos_x86_64"):
         target_system_name = "x86_64-apple-watchos{}-simulator".format(target_os_version)
     else:
@@ -734,7 +732,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         )
     elif (
         ctx.attr.cpu == "visionos_arm64" or
-        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "visionos_sim_arm64"
     ):
         apply_default_compiler_flags_feature = feature(
@@ -900,7 +897,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "tvos_sim_arm64" or
         ctx.attr.cpu == "visionos_sim_arm64" or
-        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "watchos_x86_64" or
         ctx.attr.cpu == "watchos_arm64"):
         apply_simulator_compiler_flags_feature = feature(
@@ -1443,7 +1439,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ctx.attr.cpu == "tvos_x86_64" or
         ctx.attr.cpu == "tvos_sim_arm64" or
         ctx.attr.cpu == "visionos_arm64" or
-        ctx.attr.cpu == "visionos_x86_64" or
         ctx.attr.cpu == "visionos_sim_arm64" or
         ctx.attr.cpu == "watchos_arm64_32" or
         ctx.attr.cpu == "watchos_armv7k" or

--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -54,16 +54,6 @@ def binary_test_suite(name):
     )
 
     apple_verification_test(
-        name = "{}_visionos_x86_64_simulator_test".format(name),
-        tags = [name],
-        build_type = "simulator",
-        cpus = {"visionos_cpus": "x86_64"},
-        expected_platform_type = "visionos",
-        verifier_script = "//test/shell:verify_binary.sh",
-        target_under_test = "//test/test_data:visionos_binary",
-    )
-
-    apple_verification_test(
         name = "{}_unused_symbol_is_kept_by_default".format(name),
         build_type = "simulator",
         cpus = {"ios_multi_cpus": "x86_64"},

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -68,7 +68,7 @@ def _cpu_string(*, environment_arch, platform_type, settings = {}):
         visionos_cpus = settings["//command_line_option:visionos_cpus"]
         if visionos_cpus:
             return "visionos_{}".format(visionos_cpus[0])
-        return "visionos_x86_64"
+        return "visionos_sim_arm64"
 
     fail("ERROR: Unknown platform type: {}".format(platform_type))
 


### PR DESCRIPTION
Since Apple released this without intel support, I think it's a good
time to remove it
