### PR TITLE
Update bcr CI config

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,17 +1,25 @@
 matrix:
   platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  bazel: ["6.x", "7.x", "rolling"]
 
 tasks:
   verify_targets:
     name: "Build targets under //lib"
     platform: ${{ platform }}
+    bazel: ${{ bazel }}
     build_targets:
     - '@apple_support//lib/...'
   run_tests:
     name: "Run test targets"
-    platform: "macos"
+    platform: "macos_arm64"
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@apple_support//lib/...'
     test_targets:
     - '@apple_support//test/...'
     - '--'
     # Needs the new toolchain
     - '-@apple_support//test:linking_disable_objc_apple_link_test'
+    # Needs visionOS SDK
+    - '-@apple_support//test:binary_visionos_arm64_simulator_test'
+    - '-@apple_support//test:binary_visionos_device_test'


### PR DESCRIPTION
There is a new requirement to include bazel version. Also the machines
there don't have the visionOS SDK yet
