### PR TITLE
Fix bazel HEAD compatibility

### DIFF
--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -79,6 +79,6 @@ starlark_apple_binary = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
-    fragments = ["apple", "objc", "cpp"],
+    fragments = ["apple", "objc", "cpp", "j2objc"],
     implementation = _starlark_apple_binary_impl,
 )


### PR DESCRIPTION
After moving linking behavior to starlark this is required even though
we don't care about it. It's just for tests in this case.
