### PR TITLE
Reduce number of BCR CI jobs

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  platform: ["centos7", "debian10", "macos", "ubuntu2004", "windows"]
+  platform: ["macos_arm64", "ubuntu2004"]
   bazel: ["6.x", "7.x", "rolling"]
 
 tasks:


### PR DESCRIPTION
During queue times it can get annoying. Having macOS and any Linux
should be good enough for this repo, we're just validating that things
work at all with these.
