### PR TITLE
Update bcr presubmit for more tests on 7.x+

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,18 +1,17 @@
 matrix:
-  platform: ["macos_arm64", "ubuntu2004"]
-  bazel: ["6.x", "7.x", "rolling"]
+  bazel: ["7.x", "rolling"]
 
 tasks:
   verify_targets:
     name: "Build targets under //lib"
-    platform: ${{ platform }}
+    platform: ubuntu2004
     bazel: ${{ bazel }}
     build_targets:
     - '@apple_support//lib/...'
-  run_tests:
+  run_tests_6.x:
     name: "Run test targets"
     platform: "macos_arm64"
-    bazel: ${{ bazel }}
+    bazel: 6.x
     build_targets:
     - '@apple_support//lib/...'
     test_targets:
@@ -22,6 +21,20 @@ tasks:
     - '-@apple_support//test:linking_disable_objc_apple_link_test'
     - '-@apple_support//test:linking_dead_strip_requested_test'
     - '-@apple_support//test:linking_opt_link_test'
+    - '-@apple_support//test:binary_watchos_device_arm64e_test'
+    - '-@apple_support//test:binary_watchos_device_arm64_test'
+    # Needs visionOS SDK
+    - '-@apple_support//test:binary_visionos_arm64_simulator_test'
+    - '-@apple_support//test:binary_visionos_device_test'
+  run_tests:
+    name: "Run test targets"
+    platform: "macos_arm64"
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@apple_support//lib/...'
+    test_targets:
+    - '@apple_support//test/...'
+    - '--'
     # Needs visionOS SDK
     - '-@apple_support//test:binary_visionos_arm64_simulator_test'
     - '-@apple_support//test:binary_visionos_device_test'


### PR DESCRIPTION
Something about --incompatible_enable_cc_toolchain_resolution with 6.x
makes it so we can't run all our tests on the bcr presubmit. This splits
6.x out so we can run them all for newer bazel versions.
