### PR TITLE
Add stubs for the Xcode rules in apple_support, for eventual migration from Bazel.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -31,6 +31,7 @@ filegroup(
         "//platforms:for_bazel_tests",
         "//rules:for_bazel_tests",
         "//tools:for_bazel_tests",
+        "//xcode:for_bazel_tests",
     ],
     # Exposed publicly just so other rules can use this if they set up
     # integration tests that need to copy all the support files into

--- a/xcode/BUILD
+++ b/xcode/BUILD
@@ -1,0 +1,39 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+licenses(["notice"])
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "available_xcodes",
+    srcs = ["available_xcodes.bzl"],
+    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "xcode_config",
+    srcs = ["xcode_config.bzl"],
+    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "xcode_config_alias",
+    srcs = ["xcode_config_alias.bzl"],
+    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "xcode_version",
+    srcs = ["xcode_version.bzl"],
+    visibility = ["//visibility:private"],
+)
+
+# Consumed by bazel tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)

--- a/xcode/available_xcodes.bzl
+++ b/xcode/available_xcodes.bzl
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `available_xcodes` build rule."""
+
+visibility("public")
+
+def available_xcodes(name, **kwargs):
+    # TODO: b/311385128 - Migrate the native implementation here.
+    native.available_xcodes(
+        name = name,
+        **kwargs
+    )

--- a/xcode/xcode_config.bzl
+++ b/xcode/xcode_config.bzl
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `xcode_config` build rule."""
+
+visibility("public")
+
+def xcode_config(name, **kwargs):
+    # TODO: b/311385128 - Migrate the native implementation here.
+    native.xcode_config(
+        name = name,
+        **kwargs
+    )

--- a/xcode/xcode_config_alias.bzl
+++ b/xcode/xcode_config_alias.bzl
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `xcode_config_alias` build rule."""
+
+visibility("public")
+
+def xcode_config_alias(name, **kwargs):
+    # TODO: b/311385128 - Migrate the native implementation here.
+    native.xcode_config_alias(
+        name = name,
+        **kwargs
+    )

--- a/xcode/xcode_version.bzl
+++ b/xcode/xcode_version.bzl
@@ -1,0 +1,24 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `xcode_version` build rule."""
+
+visibility("public")
+
+def xcode_version(name, **kwargs):
+    # TODO: b/311385128 - Migrate the native implementation here.
+    native.xcode_version(
+        name = name,
+        **kwargs
+    )


### PR DESCRIPTION
This change only stubs out rules; providers and flags will come later. The providers in particular need some more thought before locking down their names, since the current names (like `apple_common.XcodeVersionConfig`) don't meet Starlark provider naming conventions.

PiperOrigin-RevId: 612472977
(cherry picked from commit 217743145706a70a516987279a8027819ae892cb)
