### PR TITLE
Update platforms to 0.0.9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
-bazel_dep(name = "platforms", version = "0.0.7")
+bazel_dep(name = "platforms", version = "0.0.9")
 
 bazel_dep(
     name = "stardoc",

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -50,10 +50,10 @@ def apple_support_dependencies():
         http_archive,
         name = "platforms",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz",
         ],
-        sha256 = "3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51",
+        sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
     )
 
     apple_cc_configure()


### PR DESCRIPTION
Fixes a Bazel @ HEAD issue in `rules_swift`

```
ERROR: Error computing the main repository mapping: Label '@@platforms//host:extension.bzl' is invalid because 'host' is not a package; perhaps you meant to put the colon here: '@@platforms//:host/extension.bzl'
```