### PR TITLE
Exclude binary_macos_binary_with_spaces_test from BCR CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -23,6 +23,7 @@ tasks:
     - '-@apple_support//test:linking_opt_link_test'
     - '-@apple_support//test:binary_watchos_device_arm64e_test'
     - '-@apple_support//test:binary_watchos_device_arm64_test'
+    - '-@apple_support//test:binary_macos_binary_with_spaces_test'
     # Needs visionOS SDK
     - '-@apple_support//test:binary_visionos_arm64_simulator_test'
     - '-@apple_support//test:binary_visionos_device_test'


### PR DESCRIPTION
Failing in: https://github.com/bazelbuild/bazel-central-registry/pull/1735