### PR TITLE
Revert "Add `gcc_quoting_for_param_files` feature (#314)"

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1042,11 +1042,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         requires = [feature_set(features = ["coverage"])],
     )
 
-    gcc_quoting_for_param_files_feature = feature(
-        name = "gcc_quoting_for_param_files",
-        enabled = True,
-    )
-
     default_link_flags_feature = feature(
         name = "default_link_flags",
         enabled = True,
@@ -2583,7 +2578,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         no_objc_arc_feature,
         apple_env_feature,
         relative_ast_path_feature,
-        gcc_quoting_for_param_files_feature,
         user_link_flags_feature,
         default_link_flags_feature,
         no_deduplicate_feature,


### PR DESCRIPTION
This reverts commit 4df4418dd01229e596aa7b63a6d1594f56ed5613.

Until `dsym_path` is no longer incorrectly quoted by Bazel, or we have a workaround in place.