### PR TITLE
Reapply "Add `gcc_quoting_for_param_files` feature (#314)"

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
     repo_name = "build_bazel_apple_support",
 )
 
+bazel_dep(name = "bazel_features", version = "1.10.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "platforms", version = "0.0.9")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,10 @@ load(
 
 apple_support_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """A C++ toolchain configuration rule for macOS."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
@@ -1039,6 +1040,11 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
             ),
         ],
         requires = [feature_set(features = ["coverage"])],
+    )
+
+    gcc_quoting_for_param_files_feature = feature(
+        name = "gcc_quoting_for_param_files",
+        enabled = bazel_features.cc.fixed_dsym_path_quoting,
     )
 
     default_link_flags_feature = feature(
@@ -2577,6 +2583,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         no_objc_arc_feature,
         apple_env_feature,
         relative_ast_path_feature,
+        gcc_quoting_for_param_files_feature,
         user_link_flags_feature,
         default_link_flags_feature,
         no_deduplicate_feature,

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -56,4 +56,12 @@ def apple_support_dependencies():
         sha256 = "5eda539c841265031c2f82d8ae7a3a6490bd62176e0c038fc469eabf91f6149b",
     )
 
+    _maybe(
+        http_archive,
+        name = "bazel_features",
+        sha256 = "95fb3cfd11466b4cad6565e3647a76f89886d875556a4b827c021525cb2482bb",
+        strip_prefix = "bazel_features-1.10.0",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.10.0/bazel_features-v1.10.0.tar.gz",
+    )
+
     apple_cc_configure()


### PR DESCRIPTION
This reverts commit cf271a330b08a3bbd8ad61241d03787683d5a1c5.

This adds a dependency on **bazel_features** in order to know when it's safe to enable `gcc_quoting_for_param_files` by default.