### PR TITLE
Add `apple_support/xcode/providers.bzl` to export `XcodeVersionInfo`.

### DIFF
--- a/xcode/BUILD
+++ b/xcode/BUILD
@@ -9,25 +9,26 @@ package(
 bzl_library(
     name = "available_xcodes",
     srcs = ["available_xcodes.bzl"],
-    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
 )
 
 bzl_library(
     name = "xcode_config",
     srcs = ["xcode_config.bzl"],
-    visibility = ["//visibility:private"],
 )
 
 bzl_library(
     name = "xcode_config_alias",
     srcs = ["xcode_config_alias.bzl"],
-    visibility = ["//visibility:private"],
 )
 
 bzl_library(
     name = "xcode_version",
     srcs = ["xcode_version.bzl"],
-    visibility = ["//visibility:private"],
 )
 
 # Consumed by bazel tests.

--- a/xcode/providers.bzl
+++ b/xcode/providers.bzl
@@ -1,0 +1,20 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Providers used by the Xcode build rules and their clients."""
+
+visibility("public")
+
+# TODO: b/311385128 - Migrate the native implementation here.
+XcodeVersionInfo = apple_common.XcodeVersionConfig


### PR DESCRIPTION
This currently just re-exports the native definition of the provider (with the name slightly changed to meet Starlark's requirements). When it is migrated out of Bazel, it will be redefined here in Starlark.

PiperOrigin-RevId: 625057283
(cherry picked from commit f8d0988a2693d2741a5fc785ef0e3aa0999afd76)