### PR TITLE
Add support for layering_check

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -32,6 +32,14 @@ tasks:
     bazel: latest
     <<: *common
 
+  macos_latest_layering_check:
+    name: "Current layering_check"
+    platform: macos_arm64
+    xcode_version: "15.2"
+    bazel: latest
+    shell_commands:
+      - test/shell/layering_check_test.sh
+
   macos_last_green:
     name: "Last Green Bazel"
     bazel: last_green

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -41,6 +41,13 @@ cc_toolchain_suite(
     toolchains = dict(CC_TOOLCHAINS),
 )
 
+filegroup(
+    name = "modulemap",
+    srcs = [
+%{real_modulemap}
+    ],
+)
+
 [
     filegroup(
         name = "osx_tools_" + arch,
@@ -49,6 +56,7 @@ cc_toolchain_suite(
             ":libtool",
             ":libtool_check_unique",
             ":make_hashed_objlist.py",
+            ":modulemap",
             ":wrapped_clang",
             ":wrapped_clang_pp",
             ":xcrunwrapper.sh",
@@ -71,6 +79,7 @@ cc_toolchain_suite(
         supports_param_files = 1,
         toolchain_config = arch,
         toolchain_identifier = arch,
+        module_map = %{placeholder_modulemap},
     )
     for arch in _APPLE_ARCHS
 ]
@@ -86,6 +95,7 @@ cc_toolchain_suite(
 %{cxx_builtin_include_directories}
         ],
         tool_paths_overrides = {%{tool_paths_overrides}},
+        module_map = ":modulemap",
     )
     for arch in _APPLE_ARCHS
 ]

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -44,7 +44,7 @@ cc_toolchain_suite(
 filegroup(
     name = "modulemap",
     srcs = [
-%{real_modulemap}
+%{layering_check_modulemap}
     ],
 )
 

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2524,6 +2524,61 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
+    modulemaps = ctx.attr.module_map.files.to_list()
+    if modulemaps:
+        if len(modulemaps) != 1:
+            fail("internal error: expected 1 modulemap got:", modulemaps)
+        layering_check_feature = feature(
+            name = "layering_check",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-fmodules-strict-decluse",
+                                "-Wprivate-header",
+                                "-Xclang",
+                                "-fmodule-name=%{module_name}",
+                                "-Xclang",
+                                "-fmodule-map-file=%{module_map_file}",
+                            ],
+                        ),
+                        flag_group(
+                            iterate_over = "dependent_module_map_files",
+                            flags = [
+                                "-Xclang",
+                                "-fmodule-map-file=%{dependent_module_map_files}",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+            env_sets = [
+                env_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    env_entries = [
+                        env_entry(
+                            key = "APPLE_SUPPORT_MODULEMAP",
+                            value = modulemaps[0].path,
+                        ),
+                    ],
+                ),
+            ],
+        )
+    else:
+        layering_check_feature = feature(name = "layering_check")
+
     features = [
         # Marker features
         feature(name = "archive_param_file"),
@@ -2605,6 +2660,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         default_sanitizer_flags_feature,
         treat_warnings_as_errors_feature,
         no_warn_duplicate_libraries_feature,
+        layering_check_feature,
     ]
 
     if (ctx.attr.cpu == "darwin_x86_64" or
@@ -2678,6 +2734,7 @@ cc_toolchain_config = rule(
         "cxx_builtin_include_directories": attr.string_list(),
         "tool_paths_overrides": attr.string_dict(),
         "extra_env": attr.string_dict(),
+        "module_map": attr.label(),
         "_xcode_config": attr.label(default = configuration_field(
             fragment = "apple",
             name = "xcode_config_label",

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2537,6 +2537,8 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                         ACTION_NAMES.cpp_compile,
                         ACTION_NAMES.cpp_header_parsing,
                         ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
                     ],
                     flag_groups = [
                         flag_group(
@@ -2566,6 +2568,8 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                         ACTION_NAMES.cpp_compile,
                         ACTION_NAMES.cpp_header_parsing,
                         ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
                     ],
                     env_entries = [
                         env_entry(

--- a/crosstool/generate-modulemap.sh
+++ b/crosstool/generate-modulemap.sh
@@ -6,7 +6,7 @@ cd "$(xcode-select -p)"
 
 echo 'module "crosstool" [system] {'
 
-find .. -type f \( -name "*.h" -o -name "*.def" -o -path "*/c++/*" \) \
+find . -type f \( -name "*.h" -o -name "*.def" -o -path "*/c++/*" \) \
   | LANG=C sort -u | while read -r header; do
     echo "  textual header \"${header}\""
   done

--- a/crosstool/generate-modulemap.sh
+++ b/crosstool/generate-modulemap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(xcode-select -p)"/Platforms
+
+echo 'module "crosstool" [system] {'
+
+find ./*.platform/Developer/SDKs/*.sdk -type f \( -name "*.h" -o -name "*.def" -o -path "*/c++/*" \) \
+  | LANG=C sort -u | while read -r header; do
+    echo "  textual header \"${header}\""
+  done
+
+echo "}"

--- a/crosstool/generate-modulemap.sh
+++ b/crosstool/generate-modulemap.sh
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-cd "$(xcode-select -p)"/Platforms
+cd "$(xcode-select -p)"
 
 echo 'module "crosstool" [system] {'
 
-find ./*.platform/Developer/SDKs/*.sdk -type f \( -name "*.h" -o -name "*.def" -o -path "*/c++/*" \) \
+find .. -type f \( -name "*.h" -o -name "*.def" -o -path "*/c++/*" \) \
   | LANG=C sort -u | while read -r header; do
     echo "  textual header \"${header}\""
   done

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -62,6 +62,29 @@ def _succeeds(repository_ctx, *args):
 
     return result.return_code == 0
 
+def _generate_system_modulemap(repository_ctx, script, output):
+    env = repository_ctx.os.environ
+    result = repository_ctx.execute([
+        "env",
+        "-i",
+        "DEVELOPER_DIR={}".format(env.get("DEVELOPER_DIR", default = "")),
+        script,
+    ])
+
+    if result.return_code != 0:
+        error_msg = (
+            "return code {code}, stderr: {err}, stdout: {out}"
+        ).format(
+            code = result.return_code,
+            err = result.stderr,
+            out = result.stdout,
+        )
+        fail(output + " failed to generate. Please file an issue at " +
+             "https://github.com/bazelbuild/apple_support/issues with the following:\n" +
+             error_msg)
+
+    repository_ctx.file(output, result.stdout)
+
 def _compile_cc_file(repository_ctx, src_name, out_name):
     env = repository_ctx.os.environ
     xcrun_result = repository_ctx.execute([
@@ -149,6 +172,9 @@ def configure_osx_toolchain(repository_ctx):
     wrapped_clang_src_path = str(repository_ctx.path(
         Label("@build_bazel_apple_support//crosstool:wrapped_clang.cc"),
     ))
+    generate_modulemap_path = str(repository_ctx.path(
+        Label("@build_bazel_apple_support//crosstool:generate-modulemap.sh"),
+    ))
 
     xcode_toolchains = []
     xcodeloc_err = ""
@@ -181,6 +207,15 @@ def configure_osx_toolchain(repository_ctx):
     _compile_cc_file(repository_ctx, wrapped_clang_src_path, "wrapped_clang")
     repository_ctx.symlink("wrapped_clang", "wrapped_clang_pp")
 
+    real_modulemap = None
+    if repository_ctx.os.environ.get("APPLE_SUPPORT_LAYERING_CHECK_BETA") == "1":
+        real_modulemap = "real.modulemap"
+        _generate_system_modulemap(repository_ctx, generate_modulemap_path, real_modulemap)
+        repository_ctx.file(
+            "module.modulemap",
+            "// Placeholder to satisfy API requirements. See apple_support for real modulemap",
+        )
+
     tool_paths = {}
     gcov_path = repository_ctx.os.environ.get("GCOV")
     if gcov_path != None:
@@ -207,6 +242,8 @@ def configure_osx_toolchain(repository_ctx):
             "%{tool_paths_overrides}": ",\n            ".join(
                 ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
             ),
+            "%{real_modulemap}": "\":{}\",".format(real_modulemap) if real_modulemap else "",
+            "%{placeholder_modulemap}": "\":module.modulemap\"" if real_modulemap else "None",
         },
     )
 

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -207,13 +207,13 @@ def configure_osx_toolchain(repository_ctx):
     _compile_cc_file(repository_ctx, wrapped_clang_src_path, "wrapped_clang")
     repository_ctx.symlink("wrapped_clang", "wrapped_clang_pp")
 
-    real_modulemap = None
+    layering_check_modulemap = None
     if repository_ctx.os.environ.get("APPLE_SUPPORT_LAYERING_CHECK_BETA") == "1":
-        real_modulemap = "real.modulemap"
-        _generate_system_modulemap(repository_ctx, generate_modulemap_path, real_modulemap)
+        layering_check_modulemap = "layering_check.modulemap"
+        _generate_system_modulemap(repository_ctx, generate_modulemap_path, layering_check_modulemap)
         repository_ctx.file(
             "module.modulemap",
-            "// Placeholder to satisfy API requirements. See apple_support for real modulemap",
+            "// Placeholder to satisfy API requirements. See apple_support for usage",
         )
 
     tool_paths = {}
@@ -239,8 +239,8 @@ def configure_osx_toolchain(repository_ctx):
         {
             "%{cxx_builtin_include_directories}": "\n".join(escaped_cxx_include_directories),
             "%{features}": "\n".join(['"{}"'.format(x) for x in features]),
-            "%{placeholder_modulemap}": "\":module.modulemap\"" if real_modulemap else "None",
-            "%{real_modulemap}": "\":{}\",".format(real_modulemap) if real_modulemap else "",
+            "%{layering_check_modulemap}": "\":{}\",".format(layering_check_modulemap) if layering_check_modulemap else "",
+            "%{placeholder_modulemap}": "\":module.modulemap\"" if layering_check_modulemap else "None",
             "%{tool_paths_overrides}": ",\n            ".join(
                 ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
             ),

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -239,11 +239,11 @@ def configure_osx_toolchain(repository_ctx):
         {
             "%{cxx_builtin_include_directories}": "\n".join(escaped_cxx_include_directories),
             "%{features}": "\n".join(['"{}"'.format(x) for x in features]),
+            "%{placeholder_modulemap}": "\":module.modulemap\"" if real_modulemap else "None",
+            "%{real_modulemap}": "\":{}\",".format(real_modulemap) if real_modulemap else "",
             "%{tool_paths_overrides}": ",\n            ".join(
                 ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
             ),
-            "%{real_modulemap}": "\":{}\",".format(real_modulemap) if real_modulemap else "",
-            "%{placeholder_modulemap}": "\":module.modulemap\"" if real_modulemap else "None",
         },
     )
 

--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -57,6 +57,7 @@ _apple_cc_autoconf = repository_rule(
         _DISABLE_ENV_VAR,
         _OLD_DISABLE_ENV_VAR,
         "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
+        "APPLE_SUPPORT_LAYERING_CHECK_BETA",
         "DEVELOPER_DIR",  # Used for making sure we use the right Xcode for compiling toolchain binaries
         "GCOV",  # TODO: Remove this
         "USE_CLANG_CL",  # Kept as a hack for those who rely on this invaliding the toolchain

--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -56,8 +56,8 @@ _apple_cc_autoconf = repository_rule(
     environ = [
         _DISABLE_ENV_VAR,
         _OLD_DISABLE_ENV_VAR,
-        "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
         "APPLE_SUPPORT_LAYERING_CHECK_BETA",
+        "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
         "DEVELOPER_DIR",  # Used for making sure we use the right Xcode for compiling toolchain binaries
         "GCOV",  # TODO: Remove this
         "USE_CLANG_CL",  # Kept as a hack for those who rely on this invaliding the toolchain

--- a/crosstool/wrapped_clang.cc
+++ b/crosstool/wrapped_clang.cc
@@ -386,11 +386,11 @@ void AddLayeringCheckVFS(const std::string vfs_overlay_file,
       << modulemap
       << R"EOF(","name":"vfs.modulemap","type":"file"}],"name":")EOF"
       << developer_dir
-      << R"EOF(/Platforms","type":"directory"}],"use-external-names":false,"version":0})EOF"
+      << R"EOF(","type":"directory"}],"use-external-names":false,"version":0})EOF"
       << std::endl;
   consumer("-ivfsoverlay" + vfs_overlay_file);
   consumer("-Xclang");
-  consumer("-fmodule-map-file=" + developer_dir + "/Platforms/vfs.modulemap");
+  consumer("-fmodule-map-file=" + developer_dir + "/vfs.modulemap");
 }
 
 }  // namespace

--- a/test/layering_check/BUILD
+++ b/test/layering_check/BUILD
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
 package(features = ["layering_check"])
 
 cc_library(
@@ -31,4 +33,42 @@ cc_test(
         ":a",
         ":b",
     ],
+)
+
+objc_library(
+    name = "bad_layering_check_objc",
+    srcs = ["c.m"],
+    tags = ["manual"],
+    deps = [":b"],
+)
+
+build_test(
+    name = "bad_layering_check_objc_test",
+    targets = [":bad_layering_check_objc"],
+)
+
+objc_library(
+    name = "disabled_bad_layering_check_objc",
+    srcs = ["c.m"],
+    features = ["-layering_check"],
+    deps = [":b"],
+)
+
+build_test(
+    name = "disabled_bad_layering_check_objc_test",
+    targets = [":disabled_bad_layering_check_objc"],
+)
+
+objc_library(
+    name = "good_layering_check_objc",
+    srcs = ["c.m"],
+    deps = [
+        ":a",
+        ":b",
+    ],
+)
+
+build_test(
+    name = "good_layering_check_objc_test",
+    targets = [":good_layering_check_objc"],
 )

--- a/test/layering_check/BUILD
+++ b/test/layering_check/BUILD
@@ -1,0 +1,34 @@
+package(features = ["layering_check"])
+
+cc_library(
+    name = "a",
+    hdrs = ["a.h"],
+)
+
+cc_library(
+    name = "b",
+    hdrs = ["b.h"],
+    deps = [":a"],
+)
+
+cc_test(
+    name = "bad_layering_check",
+    srcs = ["c.cpp"],
+    deps = [":b"],
+)
+
+cc_test(
+    name = "disabled_bad_layering_check",
+    srcs = ["c.cpp"],
+    features = ["-layering_check"],
+    deps = [":b"],
+)
+
+cc_test(
+    name = "good_layering_check",
+    srcs = ["c.cpp"],
+    deps = [
+        ":a",
+        ":b",
+    ],
+)

--- a/test/layering_check/a.h
+++ b/test/layering_check/a.h
@@ -1,0 +1,1 @@
+int from_a_library = 1;

--- a/test/layering_check/b.h
+++ b/test/layering_check/b.h
@@ -1,0 +1,1 @@
+int from_b_library = 2;

--- a/test/layering_check/c.cpp
+++ b/test/layering_check/c.cpp
@@ -1,0 +1,7 @@
+#include "a.h"
+#include "b.h"
+#include <iostream>
+
+int main() {
+  std::cout << from_a_library << from_b_library << std::endl;
+}

--- a/test/layering_check/c.m
+++ b/test/layering_check/c.m
@@ -1,0 +1,8 @@
+#include "a.h"
+#include "b.h"
+#import <Foundation/Foundation.h>
+#include <stdio.h>
+
+int main() {
+    NSLog(@"%d %d", from_a_library, from_b_library);
+}

--- a/test/shell/layering_check_test.sh
+++ b/test/shell/layering_check_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_path"/unittest.bash
+
+bazel="${BAZEL:-bazel}"
+
+function test_good_layering_checks() {
+  "$bazel" test --repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1 -- //test/layering_check/... -//test/layering_check:bad_layering_check &>"$TEST_log"
+}
+
+function test_bad_layering_checks() {
+  ! "$bazel" test --repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1 -- //test/layering_check:bad_layering_check &> "$TEST_log" || fail "Expected build failure"
+
+  expect_log_once "does not depend on a module exporting"
+  expect_log "test/layering_check/c.cpp:1:10: error: module //test/layering_check:bad_layering_check does not depend on a module exporting 'a.h'" "failed wrong layering_check"
+}
+
+run_suite "layering_check tests"

--- a/test/shell/layering_check_test.sh
+++ b/test/shell/layering_check_test.sh
@@ -23,7 +23,6 @@ function test_bad_layering_checks_objc() {
 
   expect_log_once "does not depend on a module exporting"
   expect_log "test/layering_check/c.m:1:10: error: module //test/layering_check:bad_layering_check_objc does not depend on a module exporting 'a.h'" "failed wrong layering_check"
-  exit 1
 }
 
 run_suite "layering_check tests"

--- a/test/shell/layering_check_test.sh
+++ b/test/shell/layering_check_test.sh
@@ -8,7 +8,7 @@ source "$script_path"/unittest.bash
 bazel="${BAZEL:-bazel}"
 
 function test_good_layering_checks() {
-  "$bazel" test --repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1 -- //test/layering_check/... -//test/layering_check:bad_layering_check &>"$TEST_log"
+  "$bazel" test --repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1 -- //test/layering_check/... -//test/layering_check:bad_layering_check -//test/layering_check:bad_layering_check_objc_test &>"$TEST_log"
 }
 
 function test_bad_layering_checks() {
@@ -16,6 +16,13 @@ function test_bad_layering_checks() {
 
   expect_log_once "does not depend on a module exporting"
   expect_log "test/layering_check/c.cpp:1:10: error: module //test/layering_check:bad_layering_check does not depend on a module exporting 'a.h'" "failed wrong layering_check"
+}
+
+function test_bad_layering_checks_objc() {
+  ! "$bazel" test --repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1 -- //test/layering_check:bad_layering_check_objc_test &> "$TEST_log" || fail "Expected build failure"
+
+  expect_log_once "does not depend on a module exporting"
+  expect_log "test/layering_check/c.m:1:10: error: module //test/layering_check:bad_layering_check_objc does not depend on a module exporting 'a.h'" "failed wrong layering_check"
 }
 
 run_suite "layering_check tests"

--- a/test/shell/layering_check_test.sh
+++ b/test/shell/layering_check_test.sh
@@ -23,6 +23,7 @@ function test_bad_layering_checks_objc() {
 
   expect_log_once "does not depend on a module exporting"
   expect_log "test/layering_check/c.m:1:10: error: module //test/layering_check:bad_layering_check_objc does not depend on a module exporting 'a.h'" "failed wrong layering_check"
+  exit 1
 }
 
 run_suite "layering_check tests"


### PR DESCRIPTION
This feature currently applies to C/C++ compiles. It validates that for
every header you import you have a corresponding target in your deps
that surfaces that header. Bazel handles a lot of this logic internally
in the CC rules but it's up to us to provide a system-level modulemap
file that contains all system headers, so that non-system headers that
aren't in your deps are correctly flagged as a layering check violation.

To do this we use find to discover all headers in the current
DEVELOPER_DIR. There are a few potential caching issues surfaced with
this:

1. If the paths were absolute, the Xcode path would be an input. We
   avoid this by storing relative paths, and then using a vfsoverlay to
   make it "look" like the modulemap is inside of Xcode itself, which is
   the only way to make relative paths work in modulemaps.
2. If different Xcode versions have different headers, and you support
   multiple Xcode versions in your build, the modulemap file is an input
   and will cause caching issues. I think the future solution to this
   would be allow users to provide their own modulemap with a constant
   set of headers, since you likely won't care about the new or removed
   ones (and if you do you have to only support 1 of the Xcode verisons)

This is currently disabled by default and can be enabled with
`--repo_env=APPLE_SUPPORT_LAYERING_CHECK_BETA=1`. This is primarily
because of the issues above, and that generating the modulemap file
takes ~5 seconds.
