### PR TITLE
Enable supports_dynamic_linker feature on darwin

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2604,6 +2604,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ctx.attr.cpu == "darwin_arm64" or
         ctx.attr.cpu == "darwin_arm64e"):
         features.append(feature(name = "dynamic_linking_mode"))
+        features.append(feature(name = "supports_dynamic_linker"))
 
     # macOS artifact name patterns differ from the defaults only for dynamic
     # libraries.


### PR DESCRIPTION
The `supports_dynamic_linker` is not turned on, resulting shared library is not producde by cc_library or cc_test

Ref: https://github.com/bazelbuild/bazel/issues/16479 https://github.com/bazelbuild/bazel/blob/c5cb07ac4603cef03d7037d603971e1f4e9184c9/src/main/starlark/builtins_bzl/common/cc/cc_library.bzl#L94