### PR TITLE
Mark module extension as reproducible

### DIFF
--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -1,82 +1,14 @@
 """Configure the Apple CC toolchain"""
 
-load("//crosstool:osx_cc_configure.bzl", "configure_osx_toolchain")
+load("@bazel_features//:features.bzl", "bazel_features")
+load(":setup_internal.bzl", "apple_cc_autoconf", "apple_cc_autoconf_toolchains")
 
-_DISABLE_ENV_VAR = "BAZEL_NO_APPLE_CPP_TOOLCHAIN"
-_OLD_DISABLE_ENV_VAR = "BAZEL_USE_CPP_ONLY_TOOLCHAIN"
-
-def _apple_cc_autoconf_toolchains_impl(repository_ctx):
-    """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain.
-
-    Args:
-      repository_ctx: repository context
-    """
-    env = repository_ctx.os.environ
-    should_disable = _DISABLE_ENV_VAR in env and env[_DISABLE_ENV_VAR] == "1"
-    old_should_disable = _OLD_DISABLE_ENV_VAR in env and env[_OLD_DISABLE_ENV_VAR] == "1"
-
-    if should_disable or old_should_disable:
-        repository_ctx.file("BUILD", "# Apple CC toolchain autoconfiguration was disabled by {} env variable.".format(
-            _DISABLE_ENV_VAR if should_disable else _OLD_DISABLE_ENV_VAR,
-        ))
+def _apple_cc_configure_extension_impl(module_ctx):
+    apple_cc_autoconf_toolchains(name = "local_config_apple_cc_toolchains")
+    apple_cc_autoconf(name = "local_config_apple_cc")
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        return module_ctx.extension_metadata(reproducible = True)
     else:
-        repository_ctx.file(
-            "BUILD",
-            content = repository_ctx.read(
-                Label("@build_bazel_apple_support//crosstool:BUILD.toolchains"),
-            ),
-        )
-
-_apple_cc_autoconf_toolchains = repository_rule(
-    environ = [
-        _DISABLE_ENV_VAR,
-        _OLD_DISABLE_ENV_VAR,
-    ],
-    implementation = _apple_cc_autoconf_toolchains_impl,
-    configure = True,
-)
-
-def _apple_cc_autoconf_impl(repository_ctx):
-    env = repository_ctx.os.environ
-    should_disable = _DISABLE_ENV_VAR in env and env[_DISABLE_ENV_VAR] == "1"
-    old_should_disable = _OLD_DISABLE_ENV_VAR in env and env[_OLD_DISABLE_ENV_VAR] == "1"
-
-    if should_disable or old_should_disable:
-        repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled by {} env variable.".format(
-            _DISABLE_ENV_VAR if should_disable else _OLD_DISABLE_ENV_VAR,
-        ))
-    else:
-        success, error = configure_osx_toolchain(repository_ctx)
-        if not success:
-            fail("Failed to configure Apple CC toolchain, if you only have the command line tools installed and not Xcode, you cannot use this toolchain. You should either remove it or temporarily set '{}=1' in the environment: {}".format(_DISABLE_ENV_VAR, error))
-
-_apple_cc_autoconf = repository_rule(
-    environ = [
-        _DISABLE_ENV_VAR,
-        _OLD_DISABLE_ENV_VAR,
-        "APPLE_SUPPORT_LAYERING_CHECK_BETA",
-        "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
-        "DEVELOPER_DIR",  # Used for making sure we use the right Xcode for compiling toolchain binaries
-        "GCOV",  # TODO: Remove this
-        "USE_CLANG_CL",  # Kept as a hack for those who rely on this invaliding the toolchain
-        "USER",  # Used to allow paths for custom toolchains to be used by C* compiles
-        "XCODE_VERSION",  # Force re-computing the toolchain by including the current Xcode version info in an env var
-    ],
-    implementation = _apple_cc_autoconf_impl,
-    configure = True,
-)
-
-# buildifier: disable=unnamed-macro
-def apple_cc_configure():
-    _apple_cc_autoconf_toolchains(name = "local_config_apple_cc_toolchains")
-    _apple_cc_autoconf(name = "local_config_apple_cc")
-    native.register_toolchains(
-        # Use register_toolchain's target pattern expansion to register all toolchains in the package.
-        "@local_config_apple_cc_toolchains//:all",
-    )
-
-def _apple_cc_configure_extension_impl(_):
-    _apple_cc_autoconf_toolchains(name = "local_config_apple_cc_toolchains")
-    _apple_cc_autoconf(name = "local_config_apple_cc")
+        return None
 
 apple_cc_configure_extension = module_extension(implementation = _apple_cc_configure_extension_impl)

--- a/crosstool/setup_internal.bzl
+++ b/crosstool/setup_internal.bzl
@@ -1,0 +1,69 @@
+"""Configure the Apple CC toolchain"""
+
+load("//crosstool:osx_cc_configure.bzl", "configure_osx_toolchain")
+
+visibility("//lib/...")
+
+_DISABLE_ENV_VAR = "BAZEL_NO_APPLE_CPP_TOOLCHAIN"
+_OLD_DISABLE_ENV_VAR = "BAZEL_USE_CPP_ONLY_TOOLCHAIN"
+
+def _apple_cc_autoconf_toolchains_impl(repository_ctx):
+    """Generate BUILD file with 'toolchain' targets for the local host C++ toolchain.
+
+    Args:
+      repository_ctx: repository context
+    """
+    env = repository_ctx.os.environ
+    should_disable = _DISABLE_ENV_VAR in env and env[_DISABLE_ENV_VAR] == "1"
+    old_should_disable = _OLD_DISABLE_ENV_VAR in env and env[_OLD_DISABLE_ENV_VAR] == "1"
+
+    if should_disable or old_should_disable:
+        repository_ctx.file("BUILD", "# Apple CC toolchain autoconfiguration was disabled by {} env variable.".format(
+            _DISABLE_ENV_VAR if should_disable else _OLD_DISABLE_ENV_VAR,
+        ))
+    else:
+        repository_ctx.file(
+            "BUILD",
+            content = repository_ctx.read(
+                Label("@build_bazel_apple_support//crosstool:BUILD.toolchains"),
+            ),
+        )
+
+apple_cc_autoconf_toolchains = repository_rule(
+    environ = [
+        _DISABLE_ENV_VAR,
+        _OLD_DISABLE_ENV_VAR,
+    ],
+    implementation = _apple_cc_autoconf_toolchains_impl,
+    configure = True,
+)
+
+def _apple_cc_autoconf_impl(repository_ctx):
+    env = repository_ctx.os.environ
+    should_disable = _DISABLE_ENV_VAR in env and env[_DISABLE_ENV_VAR] == "1"
+    old_should_disable = _OLD_DISABLE_ENV_VAR in env and env[_OLD_DISABLE_ENV_VAR] == "1"
+
+    if should_disable or old_should_disable:
+        repository_ctx.file("BUILD", "# Apple CC autoconfiguration was disabled by {} env variable.".format(
+            _DISABLE_ENV_VAR if should_disable else _OLD_DISABLE_ENV_VAR,
+        ))
+    else:
+        success, error = configure_osx_toolchain(repository_ctx)
+        if not success:
+            fail("Failed to configure Apple CC toolchain, if you only have the command line tools installed and not Xcode, you cannot use this toolchain. You should either remove it or temporarily set '{}=1' in the environment: {}".format(_DISABLE_ENV_VAR, error))
+
+apple_cc_autoconf = repository_rule(
+    environ = [
+        _DISABLE_ENV_VAR,
+        _OLD_DISABLE_ENV_VAR,
+        "APPLE_SUPPORT_LAYERING_CHECK_BETA",
+        "BAZEL_ALLOW_NON_APPLICATIONS_XCODE",  # Signals to configure_osx_toolchain that some Xcodes may live outside of /Applications and we need to probe further when detecting/configuring them.
+        "DEVELOPER_DIR",  # Used for making sure we use the right Xcode for compiling toolchain binaries
+        "GCOV",  # TODO: Remove this
+        "USE_CLANG_CL",  # Kept as a hack for those who rely on this invaliding the toolchain
+        "USER",  # Used to allow paths for custom toolchains to be used by C* compiles
+        "XCODE_VERSION",  # Force re-computing the toolchain by including the current Xcode version info in an env var
+    ],
+    implementation = _apple_cc_autoconf_impl,
+    configure = True,
+)

--- a/lib/repositories.bzl
+++ b/lib/repositories.bzl
@@ -15,7 +15,7 @@
 """Definitions for handling Bazel repositories used by apple_support."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//crosstool:setup.bzl", "apple_cc_configure")
+load("//crosstool:setup_internal.bzl", "apple_cc_autoconf", "apple_cc_autoconf_toolchains")
 
 def _maybe(repo_rule, name, **kwargs):
     """Executes the given repository rule if it hasn't been executed already.
@@ -27,6 +27,15 @@ def _maybe(repo_rule, name, **kwargs):
     """
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
+
+# buildifier: disable=unnamed-macro
+def _apple_cc_configure():
+    apple_cc_autoconf_toolchains(name = "local_config_apple_cc_toolchains")
+    apple_cc_autoconf(name = "local_config_apple_cc")
+    native.register_toolchains(
+        # Use register_toolchain's target pattern expansion to register all toolchains in the package.
+        "@local_config_apple_cc_toolchains//:all",
+    )
 
 # buildifier: disable=unnamed-macro
 def apple_support_dependencies():
@@ -72,4 +81,4 @@ def apple_support_dependencies():
         url = "https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz",
     )
 
-    apple_cc_configure()
+    _apple_cc_configure()


### PR DESCRIPTION
This removes an unnecessary lockfile entry.

The module extension is kept in place so that `use_extension` calls don't need to be updated. The repo rules are moved into a separate file so that WORKSPACE setups don't fail on a cyclic load of `bazel_features`. The newly exposed repo rules are protected by load visibility.