### PR TITLE
Enable archive_param_file by default

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2640,7 +2640,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
 
     features = [
         # Marker features
-        feature(name = "archive_param_file"),
+        feature(name = "archive_param_file", enabled = True),
         feature(name = "compile_all_modules"),
         feature(name = "coverage"),
         feature(name = "dbg"),


### PR DESCRIPTION
This resolves an issue where build would fail if number of arguments sent to the `libtool` would exceed limit set by the OS kernel. A common error would look like this:

```
INFO: Analyzed target //app:app (132 packages loaded, 13220 targets configured).
ERROR: /Users/adincebic/developer/bazel-ios-swiftui-template/app/BUILD.bazel:16:14: Compiling Swift module //app:app.library failed: (Exit 7): worker failed: error executing SwiftCompile command (from target //app:app.library) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_swift~/tools/worker/worker swiftc ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
error: forking process failed 'bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_swift~/tools/worker/worker.runfiles/rules_swift~~non_module_deps~build_bazel_rules_swift_index_import/index-import'. Argument list too long
Target //app:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 275.752s, Critical Path: 266.07s
INFO: 49 processes: 31 internal, 18 darwin-sandbox.
ERROR: Build did NOT complete successfully
```

Or if sandbox was disabled the error would look slightly differently:

```
INFO: Invocation ID: 49eeea35-5d9c-4a1d-afee-091f25e554a4
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/49eeea35-5d9c-4a1d-afee-091f25e554a4
WARNING: For repository 'bazel_skylib', the root module requires module version bazel_skylib@1.4.2, but got bazel_skylib@1.6.1 in the resolved dependency graph.
INFO: Analyzed target //app:app (36 packages loaded, 337 targets configured).
ERROR: /Users/adincebic/developer/bazel-ios-swiftui-template/app/BUILD.bazel:16:14: Linking app/libapp.library.a failed: (Exit -1): libtool failed: error executing CppArchive command (from target //app:app.library) external/apple_support~~apple_cc_configure_extension~local_config_apple_cc/libtool -D -no_warning_for_no_symbols -static -o ... (remaining 10003 arguments skipped)
Action failed to execute: java.io.IOException: Cannot run program "/var/tmp/_bazel_adincebic/install/c15aaa505bff3c1d2abdefcf159a3893/process-wrapper" (in directory "/private/var/tmp/_bazel_adincebic/a2deb36f0e26cc77417ab5af7d6118cb/execroot/_main"): error=7, Argument list too long
Target //app:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.921s, Critical Path: 0.19s
INFO: 2 processes: 2 internal.
ERROR: Build did NOT complete successfully
```