### PR TITLE
Remove 6.x bzlmod CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,24 +8,6 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
     - '@apple_support//lib/...'
-  run_tests_6.x:
-    name: "Run test targets"
-    platform: "macos_arm64"
-    bazel: 6.x
-    build_targets:
-    - '@apple_support//lib/...'
-    test_targets:
-    - '@apple_support//test/...'
-    - '--'
-    # Needs the new toolchain
-    - '-@apple_support//test:linking_disable_objc_apple_link_test'
-    - '-@apple_support//test:linking_dead_strip_requested_test'
-    - '-@apple_support//test:linking_opt_link_test'
-    - '-@apple_support//test:binary_watchos_device_arm64e_test'
-    - '-@apple_support//test:binary_watchos_device_arm64_test'
-    # Needs visionOS SDK
-    - '-@apple_support//test:binary_visionos_arm64_simulator_test'
-    - '-@apple_support//test:binary_visionos_device_test'
   run_tests:
     name: "Run test targets"
     platform: "macos_arm64"


### PR DESCRIPTION
This still generally works, but constantly updating this list of targets
is annoying. I don't think it's worth doing just to keep BCR CI, we
still test 6.x on our own CI
