### PR TITLE
support selectively disabling NS_BLOCK_ASSERTIONS for opt builds

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2077,7 +2077,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                             "-g0",
                             "-O2",
                             "-DNDEBUG",
-                            "-DNS_BLOCK_ASSERTIONS=1",
                         ],
                     ),
                 ],
@@ -2112,6 +2111,31 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     ACTION_NAMES.clif_match,
                 ],
                 flag_groups = [flag_group(flags = ["-std=c++14"])],
+            ),
+        ],
+    )
+
+    ns_block_assertions_feature = feature(
+        name = "ns_block_assertions",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["-DNS_BLOCK_ASSERTIONS=1"])],
+                with_features = [with_feature_set(features = ["opt"])],
             ),
         ],
     )
@@ -2656,6 +2680,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         # Features with more configuration
         link_libcpp_feature,
         default_compile_flags_feature,
+        ns_block_assertions_feature,
         debug_prefix_map_pwd_is_dot_feature,
         remap_xcode_path_feature,
         generate_dsym_file_feature,

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -7,6 +7,21 @@ load(
 
 default_test = make_action_command_line_test_rule()
 
+opt_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+    },
+)
+
+disable_ns_block_assertions_feature_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": [
+            "-ns_block_assertions",
+        ],
+    },
+)
+
 def compiling_test_suite(name):
     """Tests for compilation behavior.
 
@@ -18,6 +33,30 @@ def compiling_test_suite(name):
         tags = [name],
         expected_argv = [
             "-fdebug-prefix-map=__BAZEL_EXECUTION_ROOT__=.",
+        ],
+        not_expected_argv = [
+            "-DNS_BLOCK_ASSERTIONS=1",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_main",
+    )
+
+    opt_test(
+        name = "{}_opt_link_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-DNDEBUG",
+            "-DNS_BLOCK_ASSERTIONS=1",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_main",
+    )
+
+    disable_ns_block_assertions_feature_test(
+        name = "{}_disable_ns_block_assertions_feature_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-DNDEBUG",
         ],
         not_expected_argv = [
             "-DNS_BLOCK_ASSERTIONS=1",


### PR DESCRIPTION
maintains the default behavior of passing `-DNS_BLOCK_ASSERTIONS=1` for opt builds. for builds where this is undesirable, set `--features=-ns_block_assertions` to unconditionally not-set this flag, without having to unset the entire `default_compile_flags` feature.

does not add tests, but i can add them if requested.
