### PR TITLE
Enable link time -Os in opt builds

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1124,6 +1124,27 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
+    link_osize_opt_feature = feature(
+        name = "link_osize_opt",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = _DYNAMIC_LINK_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Xlinker",
+                            "-Os",
+                        ],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["opt"]),
+                ],
+            ),
+        ],
+    )
+
     output_execpath_flags_feature = feature(
         name = "output_execpath_flags",
         flag_sets = [
@@ -2708,6 +2729,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         user_link_flags_feature,
         default_link_flags_feature,
         no_deduplicate_feature,
+        link_osize_opt_feature,
         dead_strip_feature,
         apply_implicit_frameworks_feature,
         link_cocoa_feature,

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -44,6 +44,15 @@ dsym_test = make_action_command_line_test_rule(
     },
 )
 
+opt_osize_enabled_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": [
+            "link_osize_opt",
+        ],
+    },
+)
+
 def linking_test_suite(name):
     """Tests for linking behavior.
 
@@ -118,6 +127,22 @@ def linking_test_suite(name):
             "2",
             "-ObjC",
             "-dead_strip",
+        ],
+        mnemonic = "ObjcLink",
+        target_under_test = "//test/test_data:macos_binary",
+    )
+
+    opt_osize_enabled_test(
+        name = "{}_opt_osize_enabled_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xlinker",
+            "-objc_abi_version",
+            "-Xlinker",
+            "2",
+            "-ObjC",
+            "-Xlinker",
+            "-Os",
         ],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -53,6 +53,15 @@ opt_osize_enabled_test = make_action_command_line_test_rule(
     },
 )
 
+disable_opt_osize_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": [
+            "-link_osize_opt",
+        ],
+    },
+)
+
 def linking_test_suite(name):
     """Tests for linking behavior.
 
@@ -144,6 +153,20 @@ def linking_test_suite(name):
             "-Xlinker",
             "-Os",
         ],
+        mnemonic = "ObjcLink",
+        target_under_test = "//test/test_data:macos_binary",
+    )
+
+    disable_opt_osize_test(
+        name = "{}_disable_opt_osize_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xlinker",
+            "-objc_abi_version",
+            "-Xlinker",
+            "2",
+        ],
+        not_expected_argv = ["-Os"],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
     )

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -146,11 +146,6 @@ def linking_test_suite(name):
         tags = [name],
         expected_argv = [
             "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
-            "-ObjC",
-            "-Xlinker",
             "-Os",
         ],
         mnemonic = "ObjcLink",
@@ -160,12 +155,6 @@ def linking_test_suite(name):
     disable_opt_osize_test(
         name = "{}_disable_opt_osize_test".format(name),
         tags = [name],
-        expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
-        ],
         not_expected_argv = ["-Os"],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",


### PR DESCRIPTION
`ld` starting Xcode 15 (`ld_prime`) now supports this option to perform more general code de-deduplication passes which it was not doing prior.

It is not documented anywhere but Xcode 15+ has this enabled by default in the default Release scheme (which has`Optimization Level = Fastest/Smallest -Os` by default).

I'm adding this as a separate feature so that it can be disabled but there could be an argument whether to enable this by default !

Fun note: passing any character after `-O` performs the same as `-Os`... 