### PR TITLE
Copy files into `local_config_apple_cc` instead of symlinking

### DIFF
--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -145,6 +145,9 @@ def _compile_cc_file(repository_ctx, src_name, out_name):
              "https://github.com/bazelbuild/apple_support/issues with the following:\n" +
              error_msg)
 
+def _copy_file(repository_ctx, src, dest):
+    repository_ctx.file(dest, content = repository_ctx.read(src))
+
 def configure_osx_toolchain(repository_ctx):
     """Configure C++ toolchain on macOS.
 
@@ -199,10 +202,10 @@ def configure_osx_toolchain(repository_ctx):
             "%{env}": "",
         },
     )
-    repository_ctx.symlink(xcrunwrapper, "xcrunwrapper.sh")
-    repository_ctx.symlink(libtool, "libtool")
-    repository_ctx.symlink(make_hashed_objlist, "make_hashed_objlist.py")
-    repository_ctx.symlink(cc_toolchain_config, "cc_toolchain_config.bzl")
+    _copy_file(repository_ctx, xcrunwrapper, "xcrunwrapper.sh")
+    _copy_file(repository_ctx, libtool, "libtool")
+    _copy_file(repository_ctx, make_hashed_objlist, "make_hashed_objlist.py")
+    _copy_file(repository_ctx, cc_toolchain_config, "cc_toolchain_config.bzl")
     _compile_cc_file(repository_ctx, libtool_check_unique_src_path, "libtool_check_unique")
     _compile_cc_file(repository_ctx, wrapped_clang_src_path, "wrapped_clang")
     repository_ctx.symlink("wrapped_clang", "wrapped_clang_pp")

--- a/crosstool/setup.bzl
+++ b/crosstool/setup.bzl
@@ -20,9 +20,11 @@ def _apple_cc_autoconf_toolchains_impl(repository_ctx):
             _DISABLE_ENV_VAR if should_disable else _OLD_DISABLE_ENV_VAR,
         ))
     elif repository_ctx.os.name.startswith("mac os"):
-        repository_ctx.symlink(
-            repository_ctx.path(Label("@build_bazel_apple_support//crosstool:BUILD.toolchains")),
+        repository_ctx.file(
             "BUILD",
+            content = repository_ctx.read(
+                Label("@build_bazel_apple_support//crosstool:BUILD.toolchains"),
+            ),
         )
     else:
         repository_ctx.file("BUILD", "# Apple CC toolchain autoconfiguration was disabled because you're not running on macOS")


### PR DESCRIPTION
There is a bug in Bazel where the repository symlinks can resolve (nondeterministically in a race condition way) to old contents of files. This leads to errors like:

```
ERROR: error loading package '@@apple_support~~apple_cc_configure_extension~local_config_apple_cc//': Encountered error while reading extension file 'cc_toolchain_config.bzl': Unexpected short read from file '/Users/brentley.jones/Developer/rules_xcodeproj/bazel-output-base/external/apple_support~~apple_cc_configure_extension~local_config_apple_cc/cc_toolchain_config.bzl' (expected 100570, got 95733 bytes)
```

or

```
ERROR: /Users/brentley.jones/Developer/rules_xcodeproj/bazel-output-base/external/apple_support~~apple_cc_configure_extension~local_config_apple_cc/cc_toolchain_config.bzl:2667:23: syntax error at 'newline': expected ]
```