### PR TITLE
Add no_dotd_file well known feature

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2676,6 +2676,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "only_doth_headers_in_module_maps"),
         feature(name = "opt"),
         feature(name = "parse_headers"),
+        feature(name = "no_dotd_file"),
 
         # Features with more configuration
         link_libcpp_feature,


### PR DESCRIPTION
This feature is used in bazel to disable anything related to .d files.
This is off by default but must be here to be enabled.
