### PR TITLE
Fix buildifier errors

### DIFF
--- a/test/rpaths/BUILD
+++ b/test/rpaths/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 cc_library(


### PR DESCRIPTION
Fixes:

```sh
##### :bazel: buildifier: found 4 lint issues in your WORKSPACE, BUILD and *.bzl files
--
  | <pre><code><a href="https://github.com/bazelbuild/apple_support/blob/582600d6c9882eccfaf95577498db72b19aa33d6/test/rpaths/BUILD#L3">test/rpaths/BUILD:3:1</a>: <a href="https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#native-cc">native-cc</a>: Function "cc_library" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".
  | <a href="https://github.com/bazelbuild/apple_support/blob/582600d6c9882eccfaf95577498db72b19aa33d6/test/rpaths/BUILD#L8">test/rpaths/BUILD:8:1</a>: <a href="https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#native-cc">native-cc</a>: Function "cc_binary" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".
  | <a href="https://github.com/bazelbuild/apple_support/blob/582600d6c9882eccfaf95577498db72b19aa33d6/test/rpaths/BUILD#L14">test/rpaths/BUILD:14:1</a>: <a href="https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#native-cc">native-cc</a>: Function "cc_binary" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".
  | <a href="https://github.com/bazelbuild/apple_support/blob/582600d6c9882eccfaf95577498db72b19aa33d6/test/rpaths/BUILD#L20">test/rpaths/BUILD:20:1</a>: <a href="https://github.com/bazelbuild/buildtools/blob/main/WARNINGS.md#native-cc">native-cc</a>: Function "cc_test" is not global anymore and needs to be loaded from "@rules_cc//cc:defs.bzl".</pre></code>

```

From: https://buildkite.com/bazel/apple-support-darwin/builds/2819#01948f7b-f393-4a89-9d28-b16badbe0cee