### PR TITLE
Correct the documentation for the `xcode_sdk_variant.version` attribute.

### DIFF
--- a/xcode/providers.bzl
+++ b/xcode/providers.bzl
@@ -99,8 +99,7 @@ XcodeSdkVariantInfo = provider(
             """,
         "version": """\
             `apple_common.dotted_version`. The full version string for this SDK,
-            which is of the form `<major>.<minor>.<patch>.<build>` (where the
-            fourth component is the same as the `build_version` attribute).
+            which is of the form `<major>.<minor>.<patch>`.
             """,
     },
 )

--- a/xcode/xcode_sdk_variant.bzl
+++ b/xcode/xcode_sdk_variant.bzl
@@ -155,8 +155,7 @@ xcode_sdk_variant = rule(
         "version": attr.string(
             doc = """\
                 The full version string for this SDK, which is of the form
-                `<major>.<minor>.<patch>.<build>` (where the fourth component is
-                the same as the `build_version` attribute).
+                `<major>.<minor>.<patch>`.
                 """,
         ),
     },


### PR DESCRIPTION
It was only meant to hold the user-friendly version, not the full build version (the latter is already in the `build_version` attribute).

PiperOrigin-RevId: 715041518