### PR TITLE
Use build rules for some toolchain tools

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -249,7 +249,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -282,7 +282,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -348,7 +348,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -370,7 +370,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "cc_wrapper.sh",
+                tool = ctx.file.cc_wrapper,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -387,7 +387,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "libtool",
+                tool = ctx.file.libtool,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -410,7 +410,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -433,7 +433,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang_pp",
+                tool = ctx.file.wrapped_clang_pp,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -473,7 +473,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang_pp",
+                tool = ctx.file.wrapped_clang_pp,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -495,7 +495,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -518,7 +518,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -550,7 +550,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         implies = ["apple_env"],
         tools = [
             tool(
-                path = "libtool",
+                tool = ctx.file.libtool,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -604,7 +604,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -625,7 +625,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "cc_wrapper.sh",
+                tool = ctx.file.cc_wrapper,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -647,7 +647,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -670,7 +670,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "wrapped_clang",
+                tool = ctx.file.wrapped_clang,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -692,7 +692,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         tools = [
             tool(
-                path = "cc_wrapper.sh",
+                tool = ctx.file.cc_wrapper,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -734,7 +734,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         implies = ["apple_env"],
         tools = [
             tool(
-                path = "libtool",
+                tool = ctx.file.libtool,
                 execution_requirements = xcode_execution_requirements,
             ),
         ],
@@ -2774,10 +2774,10 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
     ]
 
     tool_paths = {
-        "ar": "libtool",
+        "ar": ctx.file.libtool.path,
         "cpp": "/usr/bin/cpp",
         "dwp": "/usr/bin/dwp",
-        "gcc": "cc_wrapper.sh",
+        "gcc": ctx.file.cc_wrapper.path,
         "gcov": "/usr/bin/gcov",
         "ld": "/usr/bin/ld",
         "nm": "/usr/bin/nm",
@@ -2818,10 +2818,26 @@ cc_toolchain_config = rule(
     implementation = _impl,
     attrs = {
         "cpu": attr.string(mandatory = True),
+        "cc_wrapper": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
         "cxx_builtin_include_directories": attr.string_list(),
-        "tool_paths_overrides": attr.string_dict(),
         "extra_env": attr.string_dict(),
+        "libtool": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
         "module_map": attr.label(),
+        "tool_paths_overrides": attr.string_dict(),
+        "wrapped_clang": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "wrapped_clang_pp": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
         "_xcode_config": attr.label(default = configuration_field(
             fragment = "apple",
             name = "xcode_config_label",

--- a/crosstool/osx_cc_wrapper.sh.tpl
+++ b/crosstool/osx_cc_wrapper.sh.tpl
@@ -65,9 +65,6 @@ for i in "$@"; do
     fi
 done
 
-# Set-up the environment
-%{env}
-
 # Call the C++ compiler
 %{cc} "$@"
 

--- a/crosstool/universal_exec_tool.bzl
+++ b/crosstool/universal_exec_tool.bzl
@@ -1,0 +1,59 @@
+"""Rules for creating exec-configured universal tools for repository rules."""
+
+load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
+
+def _force_exec_impl(ctx):
+    default_into = ctx.attr.target[DefaultInfo]
+
+    return [
+        DefaultInfo(
+            files = depset(transitive = [default_into.files]),
+        ),
+    ]
+
+force_exec = rule(
+    attrs = {
+        "target": attr.label(
+            cfg = "exec",
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+    implementation = _force_exec_impl,
+)
+
+def universal_exec_tool(*, name, out, srcs):
+    apple_genrule(
+        name = name + ".target_config",
+        srcs = srcs,
+        outs = [out],
+        cmd = """
+env -i \
+  DEVELOPER_DIR=$${DEVELOPER_DIR:-} \
+  xcrun \
+    --sdk macosx \
+    clang \
+    -mmacosx-version-min=10.15 \
+    -std=c++17 \
+    -lc++ \
+    -arch arm64 \
+    -arch x86_64 \
+    -Wl,-no_adhoc_codesign \
+    -Wl,-no_uuid \
+    -O3 \
+    -o $@ \
+    $(SRCS)
+
+env -i \
+  codesign \
+    --identifier $@ \
+    --force \
+    --sign - \
+    $@
+""",
+    )
+
+    force_exec(
+        name = name,
+        target = ":{}.target_config".format(name),
+    )


### PR DESCRIPTION
This causes the tools to be built on the execution platform, which might not be the same as the host platform. This is needed to support cross-platform RBE builds.