### PR TITLE
Downgrade buildifier

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -60,4 +60,4 @@ tasks:
     bazel: last_green
     <<: *linux_common
 
-buildifier: latest
+buildifier: "7.3.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/keith/pre-commit-buildifier
-    rev: 6.3.3
+    rev: 7.3.1.2
     hooks:
       - id: buildifier
       - id: buildifier-lint


### PR DESCRIPTION
The rules_cc rules don't work with bazel 6.x
