### PR TITLE
Enable the `archive_param_file` feature by default

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2664,7 +2664,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
 
     features = [
         # Marker features
-        feature(name = "archive_param_file", enabled = True),
+        feature(name = "archive_param_file"),
         feature(name = "compile_all_modules"),
         feature(name = "coverage"),
         feature(name = "dbg"),


### PR DESCRIPTION
Matches rules_cc: https://github.com/bazelbuild/rules_cc/blob/6a2520bed08bbe47a8afcf4c43d51c2533d79ed8/cc/private/toolchain/unix_cc_toolchain_config.bzl#L1648.