### PR TITLE
add `suppress_warnings` feature

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2564,6 +2564,21 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
+    suppress_warnings_feature = feature(
+        name = "suppress_warnings",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["-w"])],
+            ),
+        ]
+    )
+
     treat_warnings_as_errors_feature = feature(
         name = "treat_warnings_as_errors",
         flag_sets = [
@@ -2744,6 +2759,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         tsan_feature,
         ubsan_feature,
         default_sanitizer_flags_feature,
+        suppress_warnings_feature,
         treat_warnings_as_errors_feature,
         no_warn_duplicate_libraries_feature,
         layering_check_feature,

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2576,7 +2576,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 ],
                 flag_groups = [flag_group(flags = ["-w"])],
             ),
-        ]
+        ],
     )
 
     treat_warnings_as_errors_feature = feature(


### PR DESCRIPTION
This is something I could use in my codebase. I would like have a way to propagate the `-w` flag to all clang-using targets, and specifically, selectively disable it in my REPO.bazel and individual targets. This would allow me to globally suppress warnings for external repositories, without enabling it in my own code, and without needing to juggle the state of the flag setting (`-w` and other diagnostic flags are mutually exclusive afaik). This is the same as how we organize the `treat_warnings_as_errors` feature today. 

Companion change in rules_swift is bazelbuild/rules_swift#1489
