### PR TITLE
Revert "Enable link time -Os in opt builds (#348)"

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1122,27 +1122,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
-    link_osize_opt_feature = feature(
-        name = "link_osize_opt",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-Xlinker",
-                            "-Os",
-                        ],
-                    ),
-                ],
-                with_features = [
-                    with_feature_set(features = ["opt"]),
-                ],
-            ),
-        ],
-    )
-
     output_execpath_flags_feature = feature(
         name = "output_execpath_flags",
         flag_sets = [
@@ -2741,7 +2720,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         user_link_flags_feature,
         default_link_flags_feature,
         no_deduplicate_feature,
-        link_osize_opt_feature,
         dead_strip_feature,
         apply_implicit_frameworks_feature,
         link_cocoa_feature,

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -44,24 +44,6 @@ dsym_test = make_action_command_line_test_rule(
     },
 )
 
-opt_osize_enabled_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:compilation_mode": "opt",
-        "//command_line_option:features": [
-            "link_osize_opt",
-        ],
-    },
-)
-
-disable_opt_osize_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:compilation_mode": "opt",
-        "//command_line_option:features": [
-            "-link_osize_opt",
-        ],
-    },
-)
-
 def linking_test_suite(name):
     """Tests for linking behavior.
 
@@ -137,25 +119,6 @@ def linking_test_suite(name):
             "-ObjC",
             "-dead_strip",
         ],
-        mnemonic = "ObjcLink",
-        target_under_test = "//test/test_data:macos_binary",
-    )
-
-    opt_osize_enabled_test(
-        name = "{}_opt_osize_enabled_test".format(name),
-        tags = [name],
-        expected_argv = [
-            "-Xlinker",
-            "-Os",
-        ],
-        mnemonic = "ObjcLink",
-        target_under_test = "//test/test_data:macos_binary",
-    )
-
-    disable_opt_osize_test(
-        name = "{}_disable_opt_osize_test".format(name),
-        tags = [name],
-        not_expected_argv = ["-Os"],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
     )


### PR DESCRIPTION
Sidestep https://github.com/bazelbuild/apple_support/issues/371 until
it's fixed in Xcode. Users who still want this vs can pass
`--linkopt=-Os`

This reverts commit 27df79d278aac09e3d973b98af2553f0a569cba3.
