### PR TITLE
Remove no_uuid and codesigning workarounds when building wrapped_clang.

### DIFF
--- a/crosstool/universal_exec_tool.bzl
+++ b/crosstool/universal_exec_tool.bzl
@@ -38,18 +38,9 @@ env -i \
     -lc++ \
     -arch arm64 \
     -arch x86_64 \
-    -Wl,-no_adhoc_codesign \
-    -Wl,-no_uuid \
     -O3 \
     -o $@ \
     $(SRCS)
-
-env -i \
-  codesign \
-    --identifier $@ \
-    --force \
-    --sign - \
-    $@
 """,
     )
 


### PR DESCRIPTION
The core problem was fixed in https://reviews.llvm.org/D111269 and these
workarounds are no longer necessary.