### PR TITLE
Update C++ standard default to 17

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -447,7 +447,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                             "-target",
                             target_system_name,
                             "-stdlib=libc++",
-                            "-std=gnu++14",
+                            "-std=gnu++17",
                         ],
                     ),
                 ],
@@ -2084,7 +2084,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     ACTION_NAMES.lto_backend,
                     ACTION_NAMES.clif_match,
                 ],
-                flag_groups = [flag_group(flags = ["-std=c++14"])],
+                flag_groups = [flag_group(flags = ["-std=c++17"])],
             ),
         ],
     )


### PR DESCRIPTION
In accordance with Google's [Foundational C++ Support matrix](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md), and given other Google projects have moved to adopt C++17 as a minimum or default ([protobuf](https://github.com/protocolbuffers/protobuf/commit/fe535930d3183b46d7e088683cbe8c49285715f8), [rules_cc](https://github.com/search?q=repo%3Abazelbuild%2Frules_cc+%22-std%22&type=code)), I'd like us to consider bumping this version in apple_support as well.

This constitutes a breaking change. It uses the change made in #219 as a reference.