### PR TITLE
Remove _xcrunwrapper

### DIFF
--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -60,11 +60,6 @@ starlark_apple_binary = rule(
                 name = "xcode_config_label",
             ),
         ),
-        "_xcrunwrapper": attr.label(
-            cfg = "exec",
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-            executable = True,
-        ),
         "binary_type": attr.string(default = "executable"),
         "bundle_loader": attr.label(),
         "deps": attr.label_list(

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -65,11 +65,6 @@ starlark_apple_static_library = rule(
                 name = "xcode_config_label",
             ),
         ),
-        "_xcrunwrapper": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
-        ),
         "additional_linker_inputs": attr.label_list(
             allow_files = True,
         ),


### PR DESCRIPTION
This used to be used internally by bazel
