### PR TITLE
Use xcrunwrapper from this repo

### DIFF
--- a/crosstool/BUILD
+++ b/crosstool/BUILD
@@ -7,6 +7,12 @@ exports_files(glob(
     ["**"],
 ))
 
+# TODO: Remove when we drop bazel 6.x
+filegroup(
+    name = "xcrunwrapper",
+    srcs = [":xcrunwrapper.sh"],
+)
+
 cc_binary(
     name = "wrapped_clang",
     testonly = True,

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -62,9 +62,10 @@ starlark_apple_binary = rule(
                 name = "xcode_config_label",
             ),
         ),
+        # TODO: Remove when we drop bazel 6.x
         "_xcrunwrapper": attr.label(
             cfg = "exec",
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
+            default = Label("//crosstool:xcrunwrapper"),
             executable = True,
         ),
         "binary_type": attr.string(default = "executable"),

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -69,10 +69,11 @@ starlark_apple_static_library = rule(
                 name = "xcode_config_label",
             ),
         ),
+        # TODO: Remove when we drop bazel 6.x
         "_xcrunwrapper": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label("@bazel_tools//tools/objc:xcrunwrapper"),
+            default = Label("//crosstool:xcrunwrapper"),
         ),
         "additional_linker_inputs": attr.label_list(
             allow_files = True,


### PR DESCRIPTION
This way we can delete the one in bazel itself. This is only used in bazel 6.x and in tests
