### PR TITLE
Update for get_cpu upstream removal

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,7 @@ load("//rules:apple_genrule.bzl", "apple_genrule")
 load(":apple_support_test.bzl", "apple_support_test")
 load(":available_xcodes_test.bzl", "available_xcodes_test")
 load(":binary_tests.bzl", "binary_test_suite")
+load(":cc_toolchain_forwarder.bzl", "cc_toolchain_forwarder")
 load(":compiling_tests.bzl", "compiling_test_suite")
 load(":linking_tests.bzl", "linking_test_suite")
 load(":starlark_apple_binary.bzl", "starlark_apple_binary")
@@ -142,4 +143,8 @@ cc_test(
     name = "cc_test_with_objc_deps",
     srcs = ["cc_test_with_objc_deps.cc"],
     deps = [":objc_lib"],
+)
+
+cc_toolchain_forwarder(
+    name = "default_cc_toolchain_forwarder",
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -147,4 +147,5 @@ cc_test(
 
 cc_toolchain_forwarder(
     name = "default_cc_toolchain_forwarder",
+    visibility = [":__subpackages__"],
 )

--- a/test/cc_toolchain_forwarder.bzl
+++ b/test/cc_toolchain_forwarder.bzl
@@ -1,0 +1,140 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Copied from rules_apple for testing
+"""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+
+TestApplePlatformInfo = provider(
+    doc = "Provides information for the currently selected Apple platforms.",
+    fields = {
+        "target_os": """
+`String` representing the selected Apple OS.
+""",
+        "target_arch": """
+`String` representing the selected target architecture or cpu type.
+""",
+        "target_environment": """
+`String` representing the selected target environment (e.g. "device", "simulator").
+""",
+    },
+)
+
+def _target_os_from_rule_ctx(ctx):
+    """Returns a `String` representing the selected Apple OS."""
+    ios_constraint = ctx.attr._ios_constraint[platform_common.ConstraintValueInfo]
+    macos_constraint = ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]
+    tvos_constraint = ctx.attr._tvos_constraint[platform_common.ConstraintValueInfo]
+    visionos_constraint = ctx.attr._visionos_constraint[platform_common.ConstraintValueInfo]
+    watchos_constraint = ctx.attr._watchos_constraint[platform_common.ConstraintValueInfo]
+
+    if ctx.target_platform_has_constraint(ios_constraint):
+        return str(apple_common.platform_type.ios)
+    elif ctx.target_platform_has_constraint(macos_constraint):
+        return str(apple_common.platform_type.macos)
+    elif ctx.target_platform_has_constraint(tvos_constraint):
+        return str(apple_common.platform_type.tvos)
+    elif ctx.target_platform_has_constraint(visionos_constraint):
+        return str(getattr(apple_common.platform_type, "visionos", None))
+    elif ctx.target_platform_has_constraint(watchos_constraint):
+        return str(apple_common.platform_type.watchos)
+    fail("ERROR: A valid Apple platform constraint could not be found from the resolved toolchain.")
+
+def _target_arch_from_rule_ctx(ctx):
+    """Returns a `String` representing the selected target architecture or cpu type."""
+    arm64_constraint = ctx.attr._arm64_constraint[platform_common.ConstraintValueInfo]
+    arm64e_constraint = ctx.attr._arm64e_constraint[platform_common.ConstraintValueInfo]
+    arm64_32_constraint = ctx.attr._arm64_32_constraint[platform_common.ConstraintValueInfo]
+    armv7k_constraint = ctx.attr._armv7k_constraint[platform_common.ConstraintValueInfo]
+    x86_64_constraint = ctx.attr._x86_64_constraint[platform_common.ConstraintValueInfo]
+
+    if ctx.target_platform_has_constraint(arm64_constraint):
+        return "arm64"
+    elif ctx.target_platform_has_constraint(arm64e_constraint):
+        return "arm64e"
+    elif ctx.target_platform_has_constraint(arm64_32_constraint):
+        return "arm64_32"
+    elif ctx.target_platform_has_constraint(armv7k_constraint):
+        return "armv7k"
+    elif ctx.target_platform_has_constraint(x86_64_constraint):
+        return "x86_64"
+    fail("ERROR: A valid Apple cpu constraint could not be found from the resolved toolchain.")
+
+def _target_environment_from_rule_ctx(ctx):
+    """Returns a `String` representing the selected environment (e.g. "device", "simulator")."""
+    simulator_constraint = ctx.attr._apple_simulator_constraint[platform_common.ConstraintValueInfo]
+    if ctx.target_platform_has_constraint(simulator_constraint):
+        return "simulator"
+
+    return "device"
+
+def _cc_toolchain_forwarder_impl(ctx):
+    return [
+        find_cpp_toolchain(ctx),
+        TestApplePlatformInfo(
+            target_os = _target_os_from_rule_ctx(ctx),
+            target_arch = _target_arch_from_rule_ctx(ctx),
+            target_environment = _target_environment_from_rule_ctx(ctx),
+        ),
+    ]
+
+cc_toolchain_forwarder = rule(
+    implementation = _cc_toolchain_forwarder_impl,
+    attrs = {
+        # Legacy style toolchain assignment.
+        "_cc_toolchain": attr.label(
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
+        # The full list of possible constraints to be resolved are assigned here.
+        "_ios_constraint": attr.label(
+            default = Label("@platforms//os:ios"),
+        ),
+        "_macos_constraint": attr.label(
+            default = Label("@platforms//os:macos"),
+        ),
+        "_tvos_constraint": attr.label(
+            default = Label("@platforms//os:tvos"),
+        ),
+        "_visionos_constraint": attr.label(
+            default = Label("@platforms//os:visionos"),
+        ),
+        "_watchos_constraint": attr.label(
+            default = Label("@platforms//os:watchos"),
+        ),
+        "_arm64_constraint": attr.label(
+            default = Label("@platforms//cpu:arm64"),
+        ),
+        "_arm64e_constraint": attr.label(
+            default = Label("@platforms//cpu:arm64e"),
+        ),
+        "_arm64_32_constraint": attr.label(
+            default = Label("@platforms//cpu:arm64_32"),
+        ),
+        "_armv7k_constraint": attr.label(
+            default = Label("@platforms//cpu:armv7k"),
+        ),
+        "_x86_64_constraint": attr.label(
+            default = Label("@platforms//cpu:x86_64"),
+        ),
+        "_apple_device_constraint": attr.label(
+            default = Label("@build_bazel_apple_support//constraints:device"),
+        ),
+        "_apple_simulator_constraint": attr.label(
+            default = Label("@build_bazel_apple_support//constraints:simulator"),
+        ),
+    },
+    toolchains = use_cpp_toolchain(),
+)

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -51,10 +51,6 @@ def _starlark_apple_binary_impl(ctx):
 # from implied attributes to function arguments, they can be removed.
 starlark_apple_binary = rule(
     attrs = {
-        "_child_configuration_dummy": attr.label(
-            cfg = apple_platform_split_transition,
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 fragment = "apple",

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -51,6 +51,7 @@ def _starlark_apple_binary_impl(ctx):
 # from implied attributes to function arguments, they can be removed.
 starlark_apple_binary = rule(
     attrs = {
+        # TODO: Remove when we drop 8.x
         "_child_configuration_dummy": attr.label(
             cfg = apple_platform_split_transition,
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -51,6 +51,10 @@ def _starlark_apple_binary_impl(ctx):
 # from implied attributes to function arguments, they can be removed.
 starlark_apple_binary = rule(
     attrs = {
+        "_child_configuration_dummy": attr.label(
+            cfg = apple_platform_split_transition,
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 fragment = "apple",

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -6,6 +6,7 @@ load("//test:transitions.bzl", "apple_platform_split_transition")
 def _starlark_apple_binary_impl(ctx):
     link_result = link_multi_arch_binary(
         ctx = ctx,
+        cc_toolchains = ctx.split_attr._cc_toolchain_forwarder,
         stamp = ctx.attr.stamp,
     )
     processed_binary = ctx.actions.declare_file(
@@ -75,6 +76,10 @@ starlark_apple_binary = rule(
         "minimum_os_version": attr.string(mandatory = True),
         "platform_type": attr.string(mandatory = True),
         "stamp": attr.int(default = -1, values = [-1, 0, 1]),
+        "_cc_toolchain_forwarder": attr.label(
+            cfg = apple_platform_split_transition,
+            default = "//test:default_cc_toolchain_forwarder",
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -6,7 +6,10 @@ load("//test:transitions.bzl", "apple_platform_split_transition")
 def _starlark_apple_static_library_impl(ctx):
     if not hasattr(apple_common.platform_type, ctx.attr.platform_type):
         fail('Unsupported platform type \"{}\"'.format(ctx.attr.platform_type))
-    link_result = link_multi_arch_static_library(ctx = ctx)
+    link_result = link_multi_arch_static_library(
+        ctx = ctx,
+        cc_toolchains = ctx.split_attr._cc_toolchain_forwarder,
+    )
     processed_library = ctx.actions.declare_file(
         "{}_lipo.a".format(ctx.label.name),
     )
@@ -83,6 +86,10 @@ starlark_apple_static_library = rule(
         "linkopts": attr.string_list(),
         "platform_type": attr.string(mandatory = True),
         "minimum_os_version": attr.string(mandatory = True),
+        "_cc_toolchain_forwarder": attr.label(
+            cfg = apple_platform_split_transition,
+            default = "//test:default_cc_toolchain_forwarder",
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -58,6 +58,10 @@ def _starlark_apple_static_library_impl(ctx):
 starlark_apple_static_library = rule(
     _starlark_apple_static_library_impl,
     attrs = {
+        "_child_configuration_dummy": attr.label(
+            cfg = apple_platform_split_transition,
+            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+        ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 fragment = "apple",

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -58,10 +58,6 @@ def _starlark_apple_static_library_impl(ctx):
 starlark_apple_static_library = rule(
     _starlark_apple_static_library_impl,
     attrs = {
-        "_child_configuration_dummy": attr.label(
-            cfg = apple_platform_split_transition,
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-        ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 fragment = "apple",

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -58,6 +58,7 @@ def _starlark_apple_static_library_impl(ctx):
 starlark_apple_static_library = rule(
     _starlark_apple_static_library_impl,
     attrs = {
+        # TODO: Remove when we drop 8.x
         "_child_configuration_dummy": attr.label(
             cfg = apple_platform_split_transition,
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),


### PR DESCRIPTION
Changes based on https://github.com/bazelbuild/rules_apple/commit/0410c024c1eac29f8cfbe4f7c78bef54c92d0422

Fixes past https://github.com/bazelbuild/bazel/commit/4f40b7fb7b0521b56767dcf147d4d13e21f3b692
