### PR TITLE
Add test for archive file hashes

### DIFF
--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -185,3 +185,12 @@ def binary_test_suite(name):
         verifier_script = "//test/shell:verify_binary.sh",
         target_under_test = "//test/test_data:ios_binary",
     )
+
+    apple_verification_test(
+        name = "{}_archive_duplicate_object_names_test".format(name),
+        tags = [name],
+        build_type = "device",
+        cpus = {"macos_cpus": "arm64"},
+        verifier_script = "//test/shell:verify_object_hashes.sh",
+        target_under_test = "//test/test_data:duplicate_object_lib",
+    )

--- a/test/shell/BUILD
+++ b/test/shell/BUILD
@@ -4,6 +4,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 exports_files([
     "verify_binary.sh",
     "verify_relative_oso.sh",
+    "verify_object_hashes.sh",
 ])
 
 filegroup(

--- a/test/shell/verify_object_hashes.sh
+++ b/test/shell/verify_object_hashes.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly binary="%{binary}s"
+output=$(ar t "$binary")
+
+if ! echo "$output" | grep -q "duplicate_a53dcba6a34993a1e83502dddc687f78.o"; then
+  echo "error: missing expected object 1" >&2
+  exit 1
+fi
+
+if ! echo "$output" | grep -q "duplicate_a4944a8448ca496d69aa3c2b860bef74.o"; then
+  echo "error: missing expected object 2" >&2
+  exit 1
+fi
+
+if ! echo "$output" | grep -q "SYMDEF"; then
+  echo "error: missing expected symdef" >&2
+  exit 1
+fi

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -137,3 +137,12 @@ starlark_apple_binary(
     tags = TARGETS_UNDER_TEST_TAGS,
     deps = [":ios_main"],
 )
+
+cc_library(
+    name = "duplicate_object_lib",
+    srcs = [
+        "duplicate.cc",
+        "nested/duplicate.cc",
+    ],
+    tags = TARGETS_UNDER_TEST_TAGS,
+)

--- a/test/test_data/duplicate.cc
+++ b/test/test_data/duplicate.cc
@@ -1,0 +1,1 @@
+void main_duplicate() {}

--- a/test/test_data/nested/duplicate.cc
+++ b/test/test_data/nested/duplicate.cc
@@ -1,0 +1,1 @@
+void nested_duplicate() {}


### PR DESCRIPTION
This makes sure we don't break our libtool behavior to hash files if
there are duplicate basenames
