### PR TITLE
Add another case for duplicate object basenames

### DIFF
--- a/test/shell/verify_object_hashes.sh
+++ b/test/shell/verify_object_hashes.sh
@@ -15,6 +15,11 @@ if ! echo "$output" | grep -q "duplicate_a4944a8448ca496d69aa3c2b860bef74.o"; th
   exit 1
 fi
 
+if ! echo "$output" | grep -q "cc_lib_ba2b8ebd486dc5bfc4cbfacde5538c29.o"; then
+  echo "error: missing expected object 3: $output" >&2
+  exit 1
+fi
+
 if ! echo "$output" | grep -q "SYMDEF"; then
   echo "error: missing expected symdef: $output" >&2
   exit 1

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -141,6 +141,7 @@ starlark_apple_binary(
 cc_library(
     name = "duplicate_object_lib",
     srcs = [
+        "cc_lib.cc",
         "duplicate.cc",
         "nested/duplicate.cc",
     ],


### PR DESCRIPTION
Interestingly today even non-duplicate names are symlinked and hashed.
I think we should probably change this just for clarities sake but at
least this encodes today's behavior
