### PR TITLE
Move toolchain tool setup out of repo rule

### DIFF
--- a/crosstool/BUILD
+++ b/crosstool/BUILD
@@ -1,5 +1,5 @@
 load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
-load("@rules_cc//cc:defs.bzl", "cc_binary")
+load(":universal_exec_tool.bzl", "force_exec", "universal_exec_tool")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,19 +8,57 @@ exports_files(glob(
     ["**"],
 ))
 
+apple_genrule(
+    name = "generate_layering_check_modulemap",
+    outs = ["layering_check.modulemap"],
+    cmd = "$(location generate-modulemap.sh) > $(OUTS)",
+    tags = ["manual"],
+    tools = ["generate-modulemap.sh"],
+)
+
+universal_exec_tool(
+    name = "exec_wrapped_clang",
+    srcs = ["wrapped_clang.cc"],
+    out = "wrapped_clang",
+)
+
+universal_exec_tool(
+    name = "exec_wrapped_clang_pp",
+    srcs = ["wrapped_clang.cc"],
+    out = "wrapped_clang_pp",
+)
+
+universal_exec_tool(
+    name = "exec_libtool",
+    srcs = ["libtool.cc"],
+    out = "libtool",
+)
+
+genrule(
+    name = "exec_cc_wrapper.target_config",
+    srcs = [
+        "osx_cc_wrapper.sh.tpl",
+        ":exec_wrapped_clang",
+    ],
+    outs = ["cc_wrapper.sh"],
+    cmd = """
+sed \
+  -e 's|%{cc}|$(location :exec_wrapped_clang)|' \
+  $(location :osx_cc_wrapper.sh.tpl) \
+  > $@
+chmod +x $@
+""",
+)
+
+force_exec(
+    name = "exec_cc_wrapper",
+    target = ":exec_cc_wrapper.target_config",
+)
+
 # TODO: Remove when we drop bazel 6.x
 filegroup(
     name = "xcrunwrapper",
     srcs = [":xcrunwrapper.sh"],
-)
-
-cc_binary(
-    name = "wrapped_clang",
-    testonly = True,
-    srcs = [
-        "wrapped_clang.cc",
-    ],
-    copts = ["-std=c++17"],
 )
 
 # Consumed by bazel tests.
@@ -29,12 +67,4 @@ filegroup(
     testonly = True,
     srcs = glob(["**"]),
     visibility = ["//:__pkg__"],
-)
-
-apple_genrule(
-    name = "generate_layering_check_modulemap",
-    outs = ["layering_check.modulemap"],
-    cmd = "$(location generate-modulemap.sh) > $(OUTS)",
-    tags = ["manual"],
-    tools = ["generate-modulemap.sh"],
 )

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -2,7 +2,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("@build_bazel_apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
-load(":universal_exec_tool.bzl", "force_exec", "universal_exec_tool")
 
 _APPLE_ARCHS = APPLE_PLATFORMS_CONSTRAINTS.keys()
 
@@ -27,46 +26,6 @@ cc_library(
     name = "malloc",
 )
 
-universal_exec_tool(
-    name = "exec_wrapped_clang",
-    srcs = ["wrapped_clang.cc"],
-    out = "wrapped_clang",
-)
-
-universal_exec_tool(
-    name = "exec_wrapped_clang_pp",
-    srcs = ["wrapped_clang.cc"],
-    out = "wrapped_clang_pp",
-)
-
-universal_exec_tool(
-    name = "exec_libtool",
-    srcs = ["libtool.cc"],
-    out = "libtool",
-)
-
-genrule(
-    name = "exec_cc_wrapper.target_config",
-    srcs = [
-        "cc_wrapper.sh.tpl",
-        ":exec_wrapped_clang",
-    ],
-    outs = ["cc_wrapper.sh"],
-    cmd = """
-sed \
-  -e 's|%{cc}|$(location //:exec_wrapped_clang)|' \
-  $(location //:cc_wrapper.sh.tpl) \
-  > $@
-chmod +x $@
-""",
-)
-
-force_exec(
-    name = "exec_cc_wrapper",
-    target = ":exec_cc_wrapper.target_config",
-)
-
-
 filegroup(
     name = "empty",
     srcs = [],
@@ -87,10 +46,10 @@ filegroup(
 filegroup(
     name = "tools",
     srcs = [
-        ":exec_cc_wrapper",
-        ":exec_libtool",
-        ":exec_wrapped_clang",
-        ":exec_wrapped_clang_pp",
+        "@build_bazel_apple_support//crosstool:exec_cc_wrapper",
+        "@build_bazel_apple_support//crosstool:exec_libtool",
+        "@build_bazel_apple_support//crosstool:exec_wrapped_clang",
+        "@build_bazel_apple_support//crosstool:exec_wrapped_clang_pp",
         ":modulemap",
     ],
 )
@@ -122,15 +81,15 @@ filegroup(
         features = [
 %{features}
         ],
-        cc_wrapper = ":exec_cc_wrapper",
+        cc_wrapper = "@build_bazel_apple_support//crosstool:exec_cc_wrapper",
         cxx_builtin_include_directories = [
 %{cxx_builtin_include_directories}
         ],
-        libtool = ":exec_libtool",
+        libtool = "@build_bazel_apple_support//crosstool:exec_libtool",
         tool_paths_overrides = {%{tool_paths_overrides}},
         module_map = ":modulemap",
-        wrapped_clang = ":exec_wrapped_clang",
-        wrapped_clang_pp = ":exec_wrapped_clang_pp",
+        wrapped_clang = "@build_bazel_apple_support//crosstool:exec_wrapped_clang",
+        wrapped_clang_pp = "@build_bazel_apple_support//crosstool:exec_wrapped_clang_pp",
     )
     for arch in _APPLE_ARCHS
 ]

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -80,14 +80,8 @@ def configure_osx_toolchain(repository_ctx):
     # https://github.com/bazelbuild/bazel/blob/ab71a1002c9c53a8061336e40f91204a2a32c38e/tools/cpp/lib_cc_configure.bzl#L17-L38
     # for more info
     xcode_locator = Label("@bazel_tools//tools/osx:xcode_locator.m")
-    cc_wrapper_template = Label("@build_bazel_apple_support//crosstool:osx_cc_wrapper.sh.tpl")
-    libtool = Label("@build_bazel_apple_support//crosstool:libtool.cc")
     cc_toolchain_config = Label("@build_bazel_apple_support//crosstool:cc_toolchain_config.bzl")
-    universal_exec_tool = Label("@build_bazel_apple_support//crosstool:universal_exec_tool.bzl")
     build_template = Label("@build_bazel_apple_support//crosstool:BUILD.tpl")
-    wrapped_clang_src_path = str(repository_ctx.path(
-        Label("@build_bazel_apple_support//crosstool:wrapped_clang.cc"),
-    ))
 
     xcode_toolchains = []
     xcodeloc_err = ""
@@ -97,17 +91,7 @@ def configure_osx_toolchain(repository_ctx):
         if not xcode_toolchains:
             return False, xcodeloc_err
 
-    # For Xcode toolchains, there's no reason to use anything other than
-    # wrapped_clang, so that we still get the Bazel Xcode placeholder
-    # substitution and other behavior for actions that invoke this
-    # cc_wrapper.sh script. The wrapped_clang binary is already hardcoded
-    # into the Objective-C crosstool actions, anyway, so this ensures that
-    # the C++ actions behave consistently.
-    _copy_file(repository_ctx, cc_wrapper_template, "cc_wrapper.sh.tpl")
-    _copy_file(repository_ctx, libtool, "libtool.cc")
     _copy_file(repository_ctx, cc_toolchain_config, "cc_toolchain_config.bzl")
-    _copy_file(repository_ctx, universal_exec_tool, "universal_exec_tool.bzl")
-    _copy_file(repository_ctx, wrapped_clang_src_path, "wrapped_clang.cc")
 
     enable_layering_check = repository_ctx.os.environ.get("APPLE_SUPPORT_LAYERING_CHECK_BETA") == "1"
 


### PR DESCRIPTION
Now that we're building the tools used in the toolchain as normal rules,
there's really no need for them to be part of the toolchain setup. This
is more understandable in general since it removes a layer of
indirection.
