### PR TITLE
Remove relative path to wrapped_clang from osx_cc_wrapper.sh

### DIFF
--- a/crosstool/BUILD
+++ b/crosstool/BUILD
@@ -36,18 +36,9 @@ universal_exec_tool(
 
 genrule(
     name = "exec_cc_wrapper.target_config",
-    srcs = [
-        "osx_cc_wrapper.sh.tpl",
-        ":exec_wrapped_clang",
-    ],
+    srcs = ["osx_cc_wrapper.sh.tpl"],
     outs = ["cc_wrapper.sh"],
-    cmd = """
-sed \
-  -e 's|%{cc}|$(location :exec_wrapped_clang)|' \
-  $(location :osx_cc_wrapper.sh.tpl) \
-  > $@
-chmod +x $@
-""",
+    cmd = "cp $(SRCS) $(OUTS)",  # Make sure this script is always beside wrapped_clang
 )
 
 force_exec(

--- a/crosstool/osx_cc_wrapper.sh.tpl
+++ b/crosstool/osx_cc_wrapper.sh.tpl
@@ -65,8 +65,11 @@ for i in "$@"; do
     fi
 done
 
-# Call the C++ compiler
-%{cc} "$@"
+# wrapped_clang uses the path it's called as to relativize paths, so we cannot
+# call it using an absolute path
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+relative_script_path=${script_path##*"$(pwd)"/}
+"$relative_script_path"/wrapped_clang "$@"
 
 # Generate an empty file if header processing succeeded.
 if [[ "${OUTPUT}" == *.h.processed ]]; then


### PR DESCRIPTION
Otherwise path mapping does not work with these files since the path to
wrapped clang contained the transition hash. Now we fetch the relative
path to wrapped_clang dynamically.
