### PR TITLE
cc_binary: support .dSYM generation

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -21,11 +21,17 @@ tasks:
     name: "7.x lowest supported"
     bazel: "7.1.0"
     <<: *common
+    test_targets:
+      - "//..."
+      - "-//test:linking_generate_cpp_dsym_test"
 
   macos_7:
     name: "7.x LTS"
     bazel: 7.x
     <<: *common
+    test_targets:
+      - "//..."
+      - "-//test:linking_generate_cpp_dsym_test"
 
   macos_latest:
     name: "Current LTS"

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -868,7 +868,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 actions = _DYNAMIC_LINK_ACTIONS,
                 flag_groups = [
                     flag_group(
-                        flags = ["-Wl,-S"],
+                        flags = ["STRIP_DEBUG_SYMBOLS"],
                         expand_if_available = "strip_debug_symbols",
                     ),
                 ],
@@ -2062,13 +2062,15 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 flag_groups = [flag_group(flags = ["-g"])],
             ),
             flag_set(
-                actions = ["objc-executable"],
+                actions = _DYNAMIC_LINK_ACTIONS,
                 flag_groups = [
                     flag_group(
                         flags = [
-                            "DSYM_HINT_LINKED_BINARY=%{linked_binary}",
+                            "DSYM_HINT_LINKED_BINARY=%{output_execpath}",
                             "DSYM_HINT_DSYM_PATH=%{dsym_path}",
                         ],
+                        # We need to check this for backwards compatibility with bazel 7
+                        expand_if_available = "dsym_path",
                     ),
                 ],
             ),

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -187,3 +187,14 @@ def linking_test_suite(name):
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
     )
+
+    dsym_test(
+        name = "{}_generate_cpp_dsym_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "DSYM_HINT_LINKED_BINARY",
+            "DSYM_HINT_DSYM_PATH",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "//test/test_data:cc_test_binary",
+    )


### PR DESCRIPTION
Add support for generating a .dSYM file if this is requested using `--apple_generate_dsym`. This change contains the following patches:

* Add `DSYM_HINT` flags to be picked up by `wrapped_clang` to generate .dSYM bundles on request.
* In `wrapped_clang.cc` make sure the linked binary is stripped after generating the .dSYM bundle first to make the .dSYM bundle contain useful information.

Adopts [changes](https://github.com/bazelbuild/bazel/pull/25881) in bazel to support .dSYM files (as part of fixing https://github.com/bazelbuild/bazel/issues/16893).