### PR TITLE
Remove old crosstool flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,1 @@
-build --enable_platform_specific_config
 build --test_output=errors
-
-build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
-build:macos --crosstool_top=@local_config_apple_cc//:toolchain
-build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain


### PR DESCRIPTION
This was for 6.x compat which we dropped
