### PR TITLE
Revert "Fix oso_prefix paths (#347)"

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -8,6 +8,8 @@ x_defaults:
       - "//..."
     test_targets:
       - "//..."
+    test_flags:
+      - "--test_tag_filters=-skipci"
 
   linux_common: &linux_common
     platform: ubuntu2004

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2040,7 +2040,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         flag_sets = [
             flag_set(
                 actions = _DYNAMIC_LINK_ACTIONS,
-                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,__BAZEL_EXECUTION_ROOT_NO_SANDBOX__/"])],
+                flag_groups = [flag_group(flags = ["-Wl,-oso_prefix,__BAZEL_EXECUTION_ROOT__/"])],
             ),
         ],
     )

--- a/test/binary_tests.bzl
+++ b/test/binary_tests.bzl
@@ -24,7 +24,10 @@ def binary_test_suite(name):
 
     apple_verification_test(
         name = "{}_relative_oso_test".format(name),
-        tags = [name],
+        tags = [
+            name,
+            "skipci",  # TODO: Enable once CI has Xcode 16.3
+        ],
         build_type = "device",
         compilation_mode = "dbg",
         cpus = {"macos_cpus": "arm64"},


### PR DESCRIPTION
This linker bug was fixed in Xcode 16.3. It would be a bit of a pain to
support both so this just reverts the fix and users on the older
versions should stay on older apple_supports until they upgrade Xcode.

Fixes https://github.com/bazelbuild/apple_support/issues/401
Fixes https://github.com/bazelbuild/apple_support/issues/404

This reverts commit 8ee7a2df6ef9a169395866f614869510b4d586e8.
