### PR TITLE
Pass -object_path_lto <path> linker flag for LTO builds

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1023,6 +1023,31 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
+    lto_object_path_feature = feature(
+        name = "lto_object_path",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = _DYNAMIC_LINK_ACTIONS,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Xlinker",
+                            "-object_path_lto",
+                            "-Xlinker",
+                            "%{output_execpath}.lto.o",
+                        ],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["full_lto"]),
+                    with_feature_set(features = ["thin_lto"]),
+                ],
+            ),
+        ],
+    )
+
     no_deduplicate_feature = feature(
         name = "no_deduplicate",
         enabled = True,
@@ -2608,6 +2633,8 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "opt"),
         feature(name = "parse_headers"),
         feature(name = "no_dotd_file"),
+        feature(name = "full_lto"),
+        feature(name = "thin_lto"),
 
         # Features with more configuration
         link_libcpp_feature,
@@ -2645,6 +2672,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         fdo_optimize_feature,
         autofdo_feature,
         lipo_feature,
+        lto_object_path_feature,
         llvm_coverage_map_format_feature,
         gcc_coverage_map_format_feature,
         coverage_prefix_map_feature,


### PR DESCRIPTION
This is needed for LTO builds, this is the path to which linker writes one big object file after performing link time optimisations, and then this object file would be used during final linking to create the App binary, without this file binary would contain invalid debug symbols, more info - https://github.com/bazelbuild/rules_swift/issues/1529 . 

To enable this you need to pass `bazel build --features=full_lto` or `bazel build --features=thin_lto`, along with `rules_swift` LTO features. 

Closes - https://github.com/bazelbuild/rules_swift/issues/1529 