### PR TITLE
Fix cxx_flags order

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2291,13 +2291,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     flag_group(
                         flags = ctx.attr.c_flags,
                     ),
-                ] if ctx.attr.c_flags else []) + [
-                    flag_group(
-                        flags = ["%{user_compile_flags}"],
-                        iterate_over = "user_compile_flags",
-                        expand_if_available = "user_compile_flags",
-                    ),
-                ],
+                ] if ctx.attr.c_flags else []),
             ),
             flag_set(
                 actions = [ACTION_NAMES.c_compile],
@@ -2322,6 +2316,27 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                         flags = ctx.attr.cxx_flags,
                     ),
                 ] if ctx.attr.cxx_flags else []),
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_compile_flags}"],
+                        iterate_over = "user_compile_flags",
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
             ),
         ],
     )

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -33,6 +33,7 @@ def compiling_test_suite(name):
         tags = [name],
         expected_argv = [
             "-fdebug-prefix-map=__BAZEL_EXECUTION_ROOT__=.",
+            "-std=c++17 -std=c++20",
         ],
         not_expected_argv = [
             "-DNS_BLOCK_ASSERTIONS=1",

--- a/test/test_data/BUILD
+++ b/test/test_data/BUILD
@@ -28,6 +28,7 @@ cc_binary(
 cc_library(
     name = "cc_main",
     srcs = ["main.cc"],
+    copts = ["-std=c++20"],
     tags = TARGETS_UNDER_TEST_TAGS,
 )
 


### PR DESCRIPTION
Default flags should come before flags passed with `--copt` or `copts = []`

Broken by 7009b77c98a67d3fea081c9db4dbcee8effc3b7e fixes https://github.com/bazelbuild/apple_support/issues/422
