### PR TITLE
Revert "Pass -object_path_lto <path> linker flag for LTO builds (#420)"

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1023,31 +1023,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
-    lto_object_path_feature = feature(
-        name = "lto_object_path",
-        enabled = True,
-        flag_sets = [
-            flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-Xlinker",
-                            "-object_path_lto",
-                            "-Xlinker",
-                            "%{output_execpath}.lto.o",
-                        ],
-                        expand_if_available = "output_execpath",
-                    ),
-                ],
-                with_features = [
-                    with_feature_set(features = ["full_lto"]),
-                    with_feature_set(features = ["thin_lto"]),
-                ],
-            ),
-        ],
-    )
-
     no_deduplicate_feature = feature(
         name = "no_deduplicate",
         enabled = True,
@@ -2635,8 +2610,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "opt"),
         feature(name = "parse_headers"),
         feature(name = "no_dotd_file"),
-        feature(name = "full_lto"),
-        feature(name = "thin_lto"),
 
         # Features with more configuration
         link_libcpp_feature,
@@ -2674,7 +2647,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         fdo_optimize_feature,
         autofdo_feature,
         lipo_feature,
-        lto_object_path_feature,
         llvm_coverage_map_format_feature,
         gcc_coverage_map_format_feature,
         coverage_prefix_map_feature,


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/apple_support/issues/423

We should re-apply with the actual configs for full_lto and thin_lto, we
should be able to write a test to verify it works too.

This reverts commit 61b44d12df0834ae26d6e089271e14c6c9a239c8.
