### PR TITLE
Workaround upstream rules_cc transition issues

### DIFF
--- a/test/cc_toolchain_forwarder.bzl
+++ b/test/cc_toolchain_forwarder.bzl
@@ -33,6 +33,14 @@ TestApplePlatformInfo = provider(
     },
 )
 
+# TODO: Remove once last_green builds without this workaround
+CcWrapperInfo = provider(
+    doc = "Workaround rules_cc transition issues",
+    fields = {
+        "provider": "The C++ toolchain provider.",
+    },
+)
+
 def _target_os_from_rule_ctx(ctx):
     """Returns a `String` representing the selected Apple OS."""
     ios_constraint = ctx.attr._ios_constraint[platform_common.ConstraintValueInfo]
@@ -83,7 +91,7 @@ def _target_environment_from_rule_ctx(ctx):
 
 def _cc_toolchain_forwarder_impl(ctx):
     return [
-        find_cpp_toolchain(ctx),
+        CcWrapperInfo(provider = find_cpp_toolchain(ctx)),
         TestApplePlatformInfo(
             target_os = _target_os_from_rule_ctx(ctx),
             target_arch = _target_arch_from_rule_ctx(ctx),

--- a/test/linking_support.bzl
+++ b/test/linking_support.bzl
@@ -2,7 +2,7 @@
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load(":cc_toolchain_forwarder.bzl", "TestApplePlatformInfo")
+load(":cc_toolchain_forwarder.bzl", "CcWrapperInfo", "TestApplePlatformInfo")
 
 def _build_avoid_library_set(avoid_dep_linking_contexts):
     avoid_library_set = dict()
@@ -80,7 +80,7 @@ def link_multi_arch_binary(*, ctx, cc_toolchains, stamp = -1):
     attr_linkopts = [token for opt in attr_linkopts for token in ctx.tokenize(opt)]
 
     for split_transition_key, child_toolchain in cc_toolchains.items():
-        cc_toolchain = child_toolchain[cc_common.CcToolchainInfo]
+        cc_toolchain = child_toolchain[CcWrapperInfo].provider
         deps = split_deps.get(split_transition_key, [])
         platform_info = child_toolchain[TestApplePlatformInfo]
 
@@ -198,7 +198,7 @@ def link_multi_arch_static_library(*, ctx, cc_toolchains):
     outputs = []
 
     for split_transition_key, child_toolchain in cc_toolchains.items():
-        cc_toolchain = child_toolchain[cc_common.CcToolchainInfo]
+        cc_toolchain = child_toolchain[CcWrapperInfo].provider
         common_variables = apple_common.compilation_support.build_common_variables(
             ctx = ctx,
             toolchain = cc_toolchain,


### PR DESCRIPTION
Since this commit https://github.com/bazelbuild/bazel/commit/31a7df06d467fe469d230b284a4368eb631d0e38

It seems that bazel is mixing up the native and starlark
CcToolchainInfo provider. This is a temporary workaround where we just
stop referencing it
