### PR TITLE
Avoid last_green bazel issue

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -55,7 +55,8 @@ tasks:
 
   macos_last_green:
     name: "Last Green Bazel"
-    bazel: last_green
+    # TODO: Move back to last_green once dependencies have rules_cc load statements
+    bazel: a0e92f32cbc49408f675202541aef831640c01a6
     <<: *common
 
   linux_latest:

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain", "cc_toolchain_suite")
 load("@build_bazel_apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 


### PR DESCRIPTION
This commit
https://github.com/bazelbuild/bazel/commit/71ca0ed111ff3d842a0d23bc3a46bd2e6745491d
broke lots of things, protobuf, abseil, and googletest no longer build
