### PR TITLE
Remove cpp_link_static_library from some flag_sets

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -320,8 +320,8 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         action_name = ACTION_NAMES.cpp_link_static_library,
         implies = [
             "archiver_flags",
-            "linker_param_file",
             "input_param_flags",
+            "linker_param_file",
             "apple_env",
         ],
         tools = [


### PR DESCRIPTION
These were all invalid for this action and are only geared towards
dynamic linking which happens with other action names. It wasn't an
error before because they are all gated on some toolchain variable being
set which was never set for static linking.
