### PR TITLE
Remove -pthread compiler flag

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -763,7 +763,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     ACTION_NAMES.preprocess_assemble,
                 ],
                 flag_groups = [
-                    flag_group(flags = ["-no-canonical-prefixes", "-pthread"]),
+                    flag_group(flags = ["-no-canonical-prefixes"]),
                 ],
             ),
         ],


### PR DESCRIPTION
On Apple platforms this does nothing

https://github.com/llvm/llvm-project/blob/5f105fe806ec228545e64d3dff6a62a434b61033/clang/lib/Driver/ToolChains/Darwin.cpp#L761-L763
