### PR TITLE
Remove per_object_debug_info feature

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -1278,26 +1278,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
-    per_object_debug_info_feature = feature(
-        name = "per_object_debug_info",
-        flag_sets = [
-            flag_set(
-                actions = [
-                    ACTION_NAMES.c_compile,
-                    ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.assemble,
-                    ACTION_NAMES.preprocess_assemble,
-                ],
-                flag_groups = [
-                    flag_group(
-                        flags = ["-gsplit-dwarf", "-g"],
-                        expand_if_available = "per_object_debug_info_file",
-                    ),
-                ],
-            ),
-        ],
-    )
-
     lipo_feature = feature(
         name = "lipo",
         flag_sets = [
@@ -2456,7 +2436,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         dependency_file_feature,
         serialized_diagnostics_file_feature,
         pic_feature,
-        per_object_debug_info_feature,
         preprocessor_defines_feature,
         framework_paths_feature,
         random_seed_feature,


### PR DESCRIPTION
This isn't supported for Mach-O binaries https://github.com/llvm/llvm-project/blob/5f105fe806ec228545e64d3dff6a62a434b61033/clang/lib/Driver/ToolChains/Clang.cpp#L6072-L6074
