### PR TITLE
Fix `build_file` attribute on `http_dmg` repository rule.

### DIFF
--- a/tools/http_dmg/http_dmg.bzl
+++ b/tools/http_dmg/http_dmg.bzl
@@ -305,7 +305,7 @@ def _http_dmg_impl(repository_ctx):
 
     build_file_content = repository_ctx.attr.build_file_content
     if repository_ctx.attr.build_file:
-        repository_ctx.read(repository_ctx.path(repository_ctx.attr.build_file))
+        build_file_content = repository_ctx.read(repository_ctx.path(repository_ctx.attr.build_file))
     repository_ctx.file("BUILD.bazel", content = build_file_content)
     repository_ctx.file("WORKSPACE.bazel", content = """workspace(name = "{}")""".format(repository_ctx.name))
 

--- a/tools/http_dmg/private/tests/BUILD.firefox.bazel
+++ b/tools/http_dmg/private/tests/BUILD.firefox.bazel
@@ -1,0 +1,5 @@
+alias(
+    name = "info_plist",
+    actual = "Firefox.app/Contents/Info.plist",
+    visibility = ["//visibility:public"],
+)

--- a/tools/http_dmg/private/tests/http_dmg_test_deps.bzl
+++ b/tools/http_dmg/private/tests/http_dmg_test_deps.bzl
@@ -20,9 +20,8 @@ def http_dmg_test_deps():
         name = "http_dmg_test_firefox",
         urls = ["https://ftp.mozilla.org/pub/firefox/releases/141.0.3/mac/en-US/Firefox%20141.0.3.dmg"],
         integrity = "sha256-u5Is2mkFQ73aofvDs8ulCMYHdIMmQ0UrwmZZUzH0LbE=",
-        build_file_content = _BUILD_FILE_CONTENT.format(
-            file = "Firefox.app/Contents/Info.plist",
-        ),
+        # Explicitly test `build_file`.
+        build_file = Label("//tools/http_dmg/private/tests:BUILD.firefox.bazel"),
     )
 
     http_dmg(


### PR DESCRIPTION
Previously the use of `build_file` did nothing. This fixes that issue and adds a regression test.