### PR TITLE
Fix dotd validation with bazel 9.x

### DIFF
--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -115,14 +115,14 @@ def _get_escaped_xcode_cxx_inc_directories(repository_ctx, xcode_toolchains):
     # Assume that everything is managed by Xcode / toolchain installations
     include_dirs = [
         "/Applications/",
-        "/Library/",
+        "/Library/",  # Global installation of CLT
     ]
 
     user = repository_ctx.os.environ.get("USER")
     if user:
         include_dirs.extend([
-            "/Users/{}/Applications/".format(user),
-            "/Users/{}/Library/".format(user),
+            "/Users/{}/Applications/".format(user),  # User only installation of Xcode
+            "/Users/{}/Library/Developer/".format(user),  # Custom Swift toolchains, user only installation of CLT
         ])
 
     # Include extra Xcode paths in case they're installed on other volumes


### PR DESCRIPTION
With 9.x bazel's default output_base on macOS changed to
`~/Library/Caches`. Previously we included `~/Library` in the system
include path allowlist that is consulted for dotd validation. That
meant any file in the output_base would be assumed to be allowed even if
it wasn't correctly defined in BUILD files.

`~/Library` is used for `~/Library/Toolchains` for custom Swift
toolchain installations that don't require `sudo` to install.
Technically you can also install the CLT there, but I imagine that would
break many other things. We now scope this better to exclude
`~/Library/Caches`
