### PR TITLE
Add supports_dynamic_library_deps

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2275,6 +2275,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "opt"),
         feature(name = "parse_headers"),
         feature(name = "no_dotd_file"),
+        feature(name = "supports_dynamic_library_deps", enabled = True),
 
         # Features with more configuration
         strip_args_feature,


### PR DESCRIPTION
This is paired with https://github.com/bazelbuild/rules_cc/pull/682
which makes binaries correctly link to shared libs if that is
requested.
