### PR TITLE
feat: Do not add objc, lkmod, lkmodc++, etc build when building iOS kernel extensions

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -861,6 +861,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
             flag_set(
                 actions = _DYNAMIC_LINK_ACTIONS,
                 flag_groups = [flag_group(flags = ["-fobjc-link-runtime"])],
+                with_features = [with_feature_set(not_features = ["kernel_extension"])],
             ),
             flag_set(
                 actions = _DYNAMIC_LINK_ACTIONS,
@@ -1734,7 +1735,12 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
 
     # Kernel extensions for Apple Silicon are arm64e.
     if (ctx.attr.cpu == "darwin_x86_64" or
-        ctx.attr.cpu == "darwin_arm64e"):
+        ctx.attr.cpu == "darwin_arm64e" or
+        ctx.attr.cpu.startswith("ios")):
+        kext_flags = ["-nostdlib", "-Xlinker", "-kext", "-lcc_kext"]
+        if not ctx.attr.cpu.startswith("ios"):
+            kext_flags.extend(["-lkmod", "-lkmodc++"])
+
         kernel_extension_feature = feature(
             name = "kernel_extension",
             flag_sets = [
@@ -1742,14 +1748,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     actions = [ACTION_NAMES.objc_executable],
                     flag_groups = [
                         flag_group(
-                            flags = [
-                                "-nostdlib",
-                                "-lkmod",
-                                "-lkmodc++",
-                                "-lcc_kext",
-                                "-Xlinker",
-                                "-kext",
-                            ],
+                            flags = kext_flags,
                         ),
                     ],
                 ),

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -251,17 +251,37 @@ def linking_test_suite(name):
         tags = [name],
         expected_argv = [
             "-nostdlib",
-            "-lkmod",
-            "-lkmodc++",
-            "-lcc_kext",
             "-Xlinker",
             "-kext",
+            "-lcc_kext",
+            "-lkmod",
+            "-lkmodc++",
         ],
         not_expected_argv = [
             "-lc++",
         ],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
+    )
+
+    kernel_extension_test(
+        name = "{}_kernel_extension_ios_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-nostdlib",
+            "-Xlinker",
+            "-kext",
+            "-lcc_kext",
+        ],
+        not_expected_argv = [
+            "-lc++",
+            "-Objc",
+            "-fobjc-link-runtime",
+            "-lkmod",
+            "-lkmodc++",
+        ],
+        mnemonic = "ObjcLink",
+        target_under_test = "//test/test_data:ios_binary",
     )
 
     default_test(


### PR DESCRIPTION
Support https://github.com/bazelbuild/rules_apple/pull/2911 by not adding objective c, kmod, kmodc++ libraries when building iOS kernel extensions.

1. Objective C doesn't work inside the iOS/macOS kernel
2. kmod and kmodc++ libraries are macOS only. The libkmod.a and libkmodc++.a artifacts in the macOS SDK will not build for iOS kernel extensions

Realistically the solution for 2 is that we provide the rest of the symbols that are provided by `libkmod.a` and `libkmodc++.a` ourselves in the kext source code ourselves.

Example symbols

`_start`
`_stop`
`_OSKextGetCurrentIdentifier`
`_OSKextGetCurrentLoadTag`
`_OSKextGetCurrentVersionString`