### PR TITLE
Remove unused hasher function

### DIFF
--- a/crosstool/libtool.cc
+++ b/crosstool/libtool.cc
@@ -256,9 +256,6 @@ void createSymlinks(std::filesystem::path temp_directory,
   for (auto file : files) {
     std::filesystem::path path = file;
 
-    std::hash<std::string> hasher;
-    hasher(file);
-
     std::string new_basename = path.stem();
     new_basename.append("_");
     new_basename.append(hash(file));


### PR DESCRIPTION
This function is marked with [[nodiscard]], which generates a warning because the result is unused.

Issue: Compiler warning when compiling crosstool/libtool.cc: [-Wunused-result] #574 https://github.com/bazelbuild/apple_support/issues/574