### PR TITLE
Add sanitize_pwd feature

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2274,6 +2274,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "opt"),
         feature(name = "parse_headers"),
         feature(name = "no_dotd_file"),
+        feature(name = "sanitize_pwd", enabled = True),
         feature(name = "set_soname", enabled = True),
 
         # Features with more configuration


### PR DESCRIPTION
This disables rules_cc from setting PWD when cross compiling https://github.com/bazelbuild/rules_cc/pull/664

This likely doesn't happen much with this toolchain, but we never need
it
