### PR TITLE
Respect DEVELOPER_DIR when invoking /usr/bin/strip

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -845,7 +845,9 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
         env_sets = [
             env_set(
-                actions = ACTION_NAME_GROUPS.all_cc_compile_actions + _DYNAMIC_LINK_ACTIONS + _STATIC_LINK_ACTIONS,
+                actions = ACTION_NAME_GROUPS.all_cc_compile_actions + _DYNAMIC_LINK_ACTIONS + _STATIC_LINK_ACTIONS + [
+                    ACTION_NAMES.strip,
+                ],
                 env_entries = [
                     env_entry(key = key, value = value)
                     for key, value in (apple_env | ctx.attr.extra_env).items()


### PR DESCRIPTION
Right now actions calling /usr/bin/strip don't seem to respect DEVELOPER_DIR. This causes them to use the copy of strip that is shipped with the system's default copy of Xcode, instead of the one that's configured for the current project.