### PR TITLE
Enable -reproducible for versions that support it

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2204,6 +2204,22 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
+    is_26_or_above = False
+    if xcode_config.xcode_version():
+        is_26_or_above = xcode_config.xcode_version() >= apple_common.dotted_version("26.0")
+
+    reproducible_linker_flag_feature = feature(
+        name = "reproducible_linker_flag",
+        enabled = "reproducible_linker_flag" in ctx.features or
+                  (is_26_or_above and "reproducible_linker_flag" not in ctx.disabled_features),
+        flag_sets = [
+            flag_set(
+                actions = _DYNAMIC_LINK_ACTIONS,
+                flag_groups = [flag_group(flags = ["-Wl,-reproducible"])],
+            ),
+        ],
+    )
+
     modulemaps = ctx.attr.module_map[DefaultInfo].files.to_list()
     if modulemaps:
         if len(modulemaps) != 1:
@@ -2347,6 +2363,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         suppress_warnings_feature,
         treat_warnings_as_errors_feature,
         no_warn_duplicate_libraries_feature,
+        reproducible_linker_flag_feature,
         layering_check_feature,
         external_include_paths_feature,
     ]

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -187,6 +187,8 @@ def configure_osx_toolchain(repository_ctx):
     features = []
     if _succeeds(repository_ctx, "ld", "-no_warn_duplicate_libraries", "-v"):
         features.append("no_warn_duplicate_libraries")
+    if _succeeds(repository_ctx, "ld", "-reproducible", "-v"):
+        features.append("reproducible_linker_flag")
 
     escaped_include_paths = _get_escaped_xcode_cxx_inc_directories(repository_ctx, xcode_toolchains)
     escaped_cxx_include_directories = []
@@ -208,7 +210,7 @@ def configure_osx_toolchain(repository_ctx):
             "%{conly_flags}": _get_starlark_list(conly_opts),
             "%{cxx_builtin_include_directories}": "\n".join(escaped_cxx_include_directories),
             "%{cxx_flags}": _get_starlark_list(cxx_opts),
-            "%{features}": "\n".join(['"{}"'.format(x) for x in features]),
+            "%{features}": "\n".join(['            "{}",'.format(x) for x in features]),
             "%{layering_check_modulemap}": "\"@build_bazel_apple_support//crosstool:exec_layering_check_modulemap\"," if enable_layering_check else "",
             "%{link_flags}": _get_starlark_list(link_opts),
             "%{placeholder_modulemap}": "\"@build_bazel_apple_support//crosstool:module.modulemap\"" if enable_layering_check else "None",

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -87,6 +87,24 @@ kernel_extension_test = make_action_command_line_test_rule(
     },
 )
 
+supported_linker_flags_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "no_warn_duplicate_libraries",
+            "reproducible_linker_flag",
+        ],
+    },
+)
+
+disabled_linker_flags_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "-no_warn_duplicate_libraries",
+            "-reproducible_linker_flag",
+        ],
+    },
+)
+
 stripopt_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:stripopt": ["-passed_arg"],
@@ -359,6 +377,40 @@ def linking_test_suite(name):
         not_expected_argv = ["-map"],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
+    )
+
+    # Assume we're on a new enough version to test that detection works
+    default_test(
+        name = "{}_default_supported_linker_flags_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Wl,-no_warn_duplicate_libraries",
+            "-Wl,-reproducible",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "//test/test_data:cc_test_binary",
+    )
+
+    supported_linker_flags_test(
+        name = "{}_supported_linker_flags_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Wl,-no_warn_duplicate_libraries",
+            "-Wl,-reproducible",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "//test/test_data:cc_test_binary",
+    )
+
+    disabled_linker_flags_test(
+        name = "{}_disabled_linker_flags_test".format(name),
+        tags = [name],
+        not_expected_argv = [
+            "-Wl,-no_warn_duplicate_libraries",
+            "-Wl,-reproducible",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "//test/test_data:cc_test_binary",
     )
 
     strip_test(


### PR DESCRIPTION
The man page isn't particularly clear what this does but Xcode enabled
it by default from 26.4.1+, and it was supported earlier than that. In
the most recent ld-classic source code this does the same thing as
ZERO_AR_DATE but presumably it could do more in ld-prime and do more
over time.
