### PR TITLE
Run `realpath` on the `$DEVELOPER_DIR` and `$SDKROOT` paths in the substitution test.

### DIFF
--- a/test/apple_support_test.bzl
+++ b/test/apple_support_test.bzl
@@ -26,8 +26,8 @@ set -eu
 
 OUTPUT_FILE="$1" ; shift
 
-echo "XCODE_PATH_ENV=$DEVELOPER_DIR" > "$OUTPUT_FILE"
-echo "SDKROOT_PATH_ENV=$SDKROOT" >> "$OUTPUT_FILE"
+echo "XCODE_PATH_ENV=$(realpath $DEVELOPER_DIR)" > "$OUTPUT_FILE"
+echo "SDKROOT_PATH_ENV=$(realpath $SDKROOT)" >> "$OUTPUT_FILE"
 
 for arg in "$@"; do
     if [[ "$arg" == @* ]]; then
@@ -84,8 +84,8 @@ function assert_not_contains() {{
     exit 1
 }}
 
-XCODE_PATH_ENV="$DEVELOPER_DIR"
-SDKROOT_PATH_ENV="$SDKROOT"
+XCODE_PATH_ENV=$(realpath "$DEVELOPER_DIR")
+SDKROOT_PATH_ENV=$(realpath "$SDKROOT")
 
 for file in "${{FILES[@]}}"; do
     assert_contains_line "$file" "XCODE_PATH_ENV=$XCODE_PATH_ENV"


### PR DESCRIPTION
In some cases, we've observed inconsistencies among the paths; sometimes we get the symlink SDK (`MacOSX.sdk`) and sometimes we get the versioned directory (`MacOSX14.2.sdk`). Either is valid, but make the test deterministic by always running `realpath`.

PiperOrigin-RevId: 613179143
(cherry picked from commit 8edac7cb67cb07647178f7d0f1d1a51ed62abd8c)
