### PR TITLE
Add compiler_param_file_on_demand feature

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2283,6 +2283,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         # Marker features
         feature(name = "archive_param_file", enabled = True),
         feature(name = "compiler_param_file"),
+        feature(name = "compiler_param_file_on_demand"),
         feature(name = "compile_all_modules"),
         feature(name = "coverage"),
         feature(name = "dbg"),


### PR DESCRIPTION
Still off by default, but could likely be enabled by default safely,
just rare enough need that it probably isn't worth changing right now.

https://github.com/bazelbuild/bazel/commit/7bab4c8a7bfad4a6d8cc4071bb99f562a798ccf9
