### PR TITLE
Make APPLE_PLATFORMS_CONSTRAINTS resilient to repo_name changes

### DIFF
--- a/configs/BUILD
+++ b/configs/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//lib:selects.bzl", "selects")
-load(":platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
+load(":platforms.bzl", "APPLE_DEVICE_CPUS", "APPLE_PLATFORMS_CONSTRAINTS", "APPLE_SIMULATOR_CPUS")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,20 +24,12 @@ selects.config_setting_group(
 
 selects.config_setting_group(
     name = "any_device",
-    match_any = [
-        cpu
-        for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()
-        if "@build_bazel_apple_support//constraints:device" in constraints
-    ],
+    match_any = APPLE_DEVICE_CPUS,
 )
 
 selects.config_setting_group(
     name = "any_simulator",
-    match_any = [
-        cpu
-        for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()
-        if "@build_bazel_apple_support//constraints:simulator" in constraints
-    ],
+    match_any = APPLE_SIMULATOR_CPUS,
 )
 
 bzl_library(

--- a/configs/platforms.bzl
+++ b/configs/platforms.bzl
@@ -4,89 +4,101 @@ APPLE_PLATFORMS_CONSTRAINTS = {
     "darwin_arm64": [
         "@platforms//os:macos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "darwin_arm64e": [
         "@platforms//os:macos",
         "@platforms//cpu:arm64e",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "darwin_x86_64": [
         "@platforms//os:macos",
         "@platforms//cpu:x86_64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "ios_arm64": [
         "@platforms//os:ios",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "ios_arm64e": [
         "@platforms//os:ios",
         "@platforms//cpu:arm64e",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "ios_x86_64": [
         "@platforms//os:ios",
         "@platforms//cpu:x86_64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "ios_sim_arm64": [
         "@platforms//os:ios",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "tvos_arm64": [
         "@platforms//os:tvos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "tvos_x86_64": [
         "@platforms//os:tvos",
         "@platforms//cpu:x86_64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "tvos_sim_arm64": [
         "@platforms//os:tvos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "visionos_arm64": [
         "@platforms//os:visionos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "visionos_sim_arm64": [
         "@platforms//os:visionos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "watchos_arm64": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
     "watchos_device_arm64": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "watchos_device_arm64e": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64e",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "watchos_arm64_32": [
         "@platforms//os:watchos",
         "@platforms//cpu:arm64_32",
-        "@build_bazel_apple_support//constraints:device",
+        Label("//constraints:device"),
     ],
     "watchos_x86_64": [
         "@platforms//os:watchos",
         "@platforms//cpu:x86_64",
-        "@build_bazel_apple_support//constraints:simulator",
+        Label("//constraints:simulator"),
     ],
 }
+
+APPLE_DEVICE_CPUS = [
+    cpu
+    for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()
+    if Label("//constraints:device") in constraints
+]
+
+APPLE_SIMULATOR_CPUS = [
+    cpu
+    for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()
+    if Label("//constraints:simulator") in constraints
+]
 
 CPU_TO_DEFAULT_PLATFORM_NAME = {
     "darwin_arm64": "macos_arm64",


### PR DESCRIPTION
I ran into an issue while working on https://github.com/bazelbuild/rules_swift/pull/1753.

After dropping all `build_bazel_` prefixes I hit:

```
ERROR: no such package '@@[unknown repo 'build_bazel_apple_support' requested from @@]//constraints'
```

This is because dict entries are plain strings, not Label objects. When a downstream consumer passes them to `target_compatible_with` (like rules_swift does), Bazel parses each string as a label using the caller's repo_mapping — not apple_support's.

The solution here is to capture repo context with `Label()` at load time.