### PR TITLE
Stop using `repo_name` and drop `build_bazel_` prefix

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -14,6 +14,6 @@ This release is compatible with: TODO
 ### MODULE.bazel Snippet
 
 \`\`\`bzl
-bazel_dep(name = "apple_support", version = "$new_version", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "$new_version")
 \`\`\`
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,6 @@ module(
     name = "apple_support",
     bazel_compatibility = [">=7.4.0"],
     compatibility_level = 1,
-    repo_name = "build_bazel_apple_support",
 )
 
 bazel_dep(name = "bazel_features", version = "1.27.0")

--- a/configs/BUILD
+++ b/configs/BUILD
@@ -10,7 +10,7 @@ selects.config_setting_group(
         cpu
         for cpu in APPLE_PLATFORMS_CONSTRAINTS.keys()
     ] + [
-        "@build_bazel_apple_support//constraints:apple",
+        "@apple_support//constraints:apple",
     ],
 )
 

--- a/crosstool/BUILD
+++ b/crosstool/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
+load("@apple_support//rules:apple_genrule.bzl", "apple_genrule")
 load(":universal_exec_tool.bzl", "force_exec", "universal_exec_tool")
 
 package(default_visibility = ["//visibility:public"])

--- a/crosstool/BUILD.toolchains
+++ b/crosstool/BUILD.toolchains
@@ -1,4 +1,4 @@
-load("@build_bazel_apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
+load("@apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
 
 _OSX_DEVELOPER_PLATFORM_CPUS = [
     "arm64",

--- a/crosstool/BUILD.tpl
+++ b/crosstool/BUILD.tpl
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain", "cc_toolchain_suite")
-load("@build_bazel_apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
+load("@apple_support//configs:platforms.bzl", "APPLE_PLATFORMS_CONSTRAINTS")
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 
 _APPLE_ARCHS = APPLE_PLATFORMS_CONSTRAINTS.keys()
@@ -47,9 +47,9 @@ filegroup(
 filegroup(
     name = "tools",
     srcs = [
-        "@build_bazel_apple_support//crosstool:exec_libtool",
-        "@build_bazel_apple_support//crosstool:exec_wrapped_clang",
-        "@build_bazel_apple_support//crosstool:exec_wrapped_clang_pp",
+        "@apple_support//crosstool:exec_libtool",
+        "@apple_support//crosstool:exec_wrapped_clang",
+        "@apple_support//crosstool:exec_wrapped_clang_pp",
         ":modulemap",
     ],
 )
@@ -84,15 +84,15 @@ filegroup(
         cxx_builtin_include_directories = [
 %{cxx_builtin_include_directories}
         ],
-        libtool = "@build_bazel_apple_support//crosstool:exec_libtool",
+        libtool = "@apple_support//crosstool:exec_libtool",
         tool_paths_overrides = {%{tool_paths_overrides}},
         c_flags = [%{c_flags}],
         conly_flags = [%{conly_flags}],
         cxx_flags = [%{cxx_flags}],
         link_flags = [%{link_flags}],
         module_map = ":modulemap",
-        wrapped_clang = "@build_bazel_apple_support//crosstool:exec_wrapped_clang",
-        wrapped_clang_pp = "@build_bazel_apple_support//crosstool:exec_wrapped_clang_pp",
+        wrapped_clang = "@apple_support//crosstool:exec_wrapped_clang",
+        wrapped_clang_pp = "@apple_support//crosstool:exec_wrapped_clang_pp",
     )
     for arch in _APPLE_ARCHS
 ]

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """A C++ toolchain configuration rule for macOS."""
 
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
@@ -30,7 +31,6 @@ load(
     "variable_with_value",
     "with_feature_set",
 )
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES", "ACTION_NAME_GROUPS")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/toolchains:cc_toolchain_config_info.bzl", "CcToolchainConfigInfo")

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -162,8 +162,8 @@ def configure_osx_toolchain(repository_ctx):
     # https://github.com/bazelbuild/bazel/blob/ab71a1002c9c53a8061336e40f91204a2a32c38e/tools/cpp/lib_cc_configure.bzl#L17-L38
     # for more info
     xcode_locator = Label("@bazel_tools//tools/osx:xcode_locator.m")
-    cc_toolchain_config = Label("@build_bazel_apple_support//crosstool:cc_toolchain_config.bzl")
-    build_template = Label("@build_bazel_apple_support//crosstool:BUILD.tpl")
+    cc_toolchain_config = Label("@apple_support//crosstool:cc_toolchain_config.bzl")
+    build_template = Label("@apple_support//crosstool:BUILD.tpl")
 
     xcode_toolchains = []
     xcodeloc_err = ""
@@ -211,9 +211,9 @@ def configure_osx_toolchain(repository_ctx):
             "%{cxx_builtin_include_directories}": "\n".join(escaped_cxx_include_directories),
             "%{cxx_flags}": _get_starlark_list(cxx_opts),
             "%{features}": "\n".join(['            "{}",'.format(x) for x in features]),
-            "%{layering_check_modulemap}": "\"@build_bazel_apple_support//crosstool:exec_layering_check_modulemap\"," if enable_layering_check else "",
+            "%{layering_check_modulemap}": "\"@apple_support//crosstool:exec_layering_check_modulemap\"," if enable_layering_check else "",
             "%{link_flags}": _get_starlark_list(link_opts),
-            "%{placeholder_modulemap}": "\"@build_bazel_apple_support//crosstool:module.modulemap\"" if enable_layering_check else "None",
+            "%{placeholder_modulemap}": "\"@apple_support//crosstool:module.modulemap\"" if enable_layering_check else "None",
             "%{tool_paths_overrides}": ",\n            ".join(
                 ['"%s": "%s"' % (k, v) for k, v in tool_paths.items()],
             ),

--- a/crosstool/setup_internal.bzl
+++ b/crosstool/setup_internal.bzl
@@ -25,7 +25,7 @@ def _apple_cc_autoconf_toolchains_impl(repository_ctx):
         repository_ctx.file(
             "BUILD",
             content = repository_ctx.read(
-                Label("@build_bazel_apple_support//crosstool:BUILD.toolchains"),
+                Label("@apple_support//crosstool:BUILD.toolchains"),
             ),
         )
 

--- a/crosstool/universal_exec_tool.bzl
+++ b/crosstool/universal_exec_tool.bzl
@@ -1,6 +1,6 @@
 """Rules for creating exec-configured universal tools for repository rules."""
 
-load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
+load("@apple_support//rules:apple_genrule.bzl", "apple_genrule")
 
 def _force_exec_impl(ctx):
     default_into = ctx.attr.target[DefaultInfo]

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,11 +14,11 @@ targeting Apple Platforms (and Xcode) as well as some Rules directly.
   </thead>
   <tbody>
     <tr>
-      <td valign="top"><code>@build_bazel_apple_support//lib:apple_support.bzl</code></td>
+      <td valign="top"><code>@apple_support//lib:apple_support.bzl</code></td>
       <td valign="top"><code><a href="apple_support.md">apple_support</a></code><br/></td>
     </tr>
     <tr>
-      <td valign="top"><code>@build_bazel_apple_support//lib:xcode_support.bzl</code></td>
+      <td valign="top"><code>@apple_support//lib:xcode_support.bzl</code></td>
       <td valign="top"><code><a href="xcode_support.md">xcode_support</a></code><br/></td>
     </tr>
   </tbody>
@@ -35,15 +35,15 @@ targeting Apple Platforms (and Xcode) as well as some Rules directly.
   </thead>
   <tbody>
     <tr>
-      <td valign="top"><code>@build_bazel_apple_support//rules:apple_genrule.bzl</code></td>
+      <td valign="top"><code>@apple_support//rules:apple_genrule.bzl</code></td>
       <td valign="top"><code><a href="rules.md#apple_genrule">apple_genrule</a></code><br/></td>
     </tr>
     <tr>
-      <td valign="top"><code>@build_bazel_apple_support//rules:toolchain_substitution.bzl</code></td>
+      <td valign="top"><code>@apple_support//rules:toolchain_substitution.bzl</code></td>
       <td valign="top"><code><a href="rules.md#toolchain_substitution">toolchain_substitution</a></code><br/></td>
     </tr>
     <tr>
-      <td valign="top"><code>@build_bazel_apple_support//rules:universal_binary.bzl</code></td>
+      <td valign="top"><code>@apple_support//rules:universal_binary.bzl</code></td>
       <td valign="top"><code><a href="rules.md#universal_binary">universal_binary</a></code><br/></td>
     </tr>
   </tbody>

--- a/doc/apple_support.md
+++ b/doc/apple_support.md
@@ -8,7 +8,7 @@ Apple platforms.
 To use these in your Starlark code, simply load the module; for example:
 
 ```build
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 ```
 On this page:
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -23,7 +23,7 @@ make variables. This rule will only run on a Mac.
 Example of use:
 
 ```
-load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
+load("@apple_support//rules:apple_genrule.bzl", "apple_genrule")
 
 apple_genrule(
     name = "world",
@@ -92,7 +92,7 @@ target's attributes. Useful for passing custom tools to a compile or link.
 ### Example:
 
 ```bzl
-load("@build_bazel_apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
+load("@apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
 
 toolchain_substitution(
     name = "resource_rules",

--- a/doc/xcode_support.md
+++ b/doc/xcode_support.md
@@ -8,7 +8,7 @@ need to change what they do based on attributes of the active Xcode.
 To use these in your Starlark code, simply load the module; for example:
 
 ```build
-load("@build_bazel_apple_support//lib:xcode_support.bzl", "xcode_support")
+load("@apple_support//lib:xcode_support.bzl", "xcode_support")
 ```
 On this page:
 

--- a/lib/apple_support.bzl
+++ b/lib/apple_support.bzl
@@ -19,7 +19,7 @@ Apple platforms.
 To use these in your Starlark code, simply load the module; for example:
 
 ```build
-load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@apple_support//lib:apple_support.bzl", "apple_support")
 ```
 """
 
@@ -232,7 +232,7 @@ def _action_required_attrs():
     """
     return {
         "_xcode_config": attr.label(
-            default = "@build_bazel_apple_support//xcode:version_config",
+            default = "@apple_support//xcode:version_config",
         ),
     }
 
@@ -274,7 +274,7 @@ def _platform_constraint_attrs():
             default = Label("@platforms//cpu:x86_64"),
         ),
         "_pointer_authentication_constraint": attr.label(
-            default = Label("@build_bazel_apple_support//constraints:pointer_authentication"),
+            default = Label("@apple_support//constraints:pointer_authentication"),
         ),
         "_apple_device_constraint": attr.label(
             default = Label("//constraints:device"),

--- a/lib/xcode_support.bzl
+++ b/lib/xcode_support.bzl
@@ -20,12 +20,12 @@ need to change what they do based on attributes of the active Xcode.
 To use these in your Starlark code, simply load the module; for example:
 
 ```build
-load("@build_bazel_apple_support//lib:xcode_support.bzl", "xcode_support")
+load("@apple_support//lib:xcode_support.bzl", "xcode_support")
 ```
 """
 
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeSdkVariantInfo",
 )
 

--- a/platforms/BUILD
+++ b/platforms/BUILD
@@ -10,7 +10,7 @@ package(default_visibility = ["//visibility:public"])
     platform(
         name = cpu,
         constraint_values = constraints + [
-            "@build_bazel_apple_support//constraints:apple",
+            "@apple_support//constraints:apple",
         ],
     )
     for cpu, constraints in APPLE_PLATFORMS_CONSTRAINTS.items()

--- a/rules/private/apple_genrule.bzl
+++ b/rules/private/apple_genrule.bzl
@@ -150,7 +150,7 @@ make variables. This rule will only run on a Mac.
 Example of use:
 
 ```
-load("@build_bazel_apple_support//rules:apple_genrule.bzl", "apple_genrule")
+load("@apple_support//rules:apple_genrule.bzl", "apple_genrule")
 
 apple_genrule(
     name = "world",

--- a/rules/toolchain_substitution.bzl
+++ b/rules/toolchain_substitution.bzl
@@ -33,7 +33,7 @@ target's attributes. Useful for passing custom tools to a compile or link.
 ### Example:
 
 ```bzl
-load("@build_bazel_apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
+load("@apple_support//rules:toolchain_substitution.bzl", "toolchain_substitution")
 
 toolchain_substitution(
     name = "resource_rules",

--- a/test/cc_toolchain_forwarder.bzl
+++ b/test/cc_toolchain_forwarder.bzl
@@ -136,10 +136,10 @@ cc_toolchain_forwarder = rule(
             default = Label("@platforms//cpu:x86_64"),
         ),
         "_apple_device_constraint": attr.label(
-            default = Label("@build_bazel_apple_support//constraints:device"),
+            default = Label("@apple_support//constraints:device"),
         ),
         "_apple_simulator_constraint": attr.label(
-            default = Label("@build_bazel_apple_support//constraints:simulator"),
+            default = Label("@apple_support//constraints:simulator"),
         ),
     },
     toolchains = use_cpp_toolchain(),

--- a/test/shell/integration_test_setup.sh
+++ b/test/shell/integration_test_setup.sh
@@ -19,5 +19,5 @@ function print_message_and_exit() {
   echo "$1" >&2; exit 1;
 }
 
-source "$(rlocation build_bazel_apple_support/test/shell/unittest.bash)" \
+source "$(rlocation apple_support/test/shell/unittest.bash)" \
   || print_message_and_exit "unittest.bash not found!"

--- a/test/shell/wrapped_clang_test.sh
+++ b/test/shell/wrapped_clang_test.sh
@@ -42,9 +42,9 @@ fi
 
 
 # Load test environment
-source "$(rlocation "build_bazel_apple_support/test/shell/unittest.bash")" \
+source "$(rlocation "apple_support/test/shell/unittest.bash")" \
   || { echo "unittest.bash not found!" >&2; exit 1; }
-WRAPPED_CLANG=$(rlocation "build_bazel_apple_support/crosstool/wrapped_clang")
+WRAPPED_CLANG=$(rlocation "apple_support/crosstool/wrapped_clang")
 
 
 # This env var tells wrapped_clang to log its command instead of running.

--- a/test/xcode_config_test.bzl
+++ b/test/xcode_config_test.bzl
@@ -41,7 +41,7 @@ version_retriever = rule(
     implementation = _version_retriever_impl,
     attrs = {
         "_xcode_config": attr.label(
-            default = "@build_bazel_apple_support//xcode:version_config",
+            default = "@apple_support//xcode:version_config",
         ),
     },
     fragments = ["apple"],
@@ -54,7 +54,7 @@ provider_grabber = rule(
     implementation = _provider_grabber_impl,
     attrs = {
         "_xcode_config": attr.label(
-            default = "@build_bazel_apple_support//xcode:version_config",
+            default = "@apple_support//xcode:version_config",
         ),
     },
     fragments = ["apple"],
@@ -67,7 +67,7 @@ provider_grabber_aspect = aspect(
     implementation = _provider_grabber_aspect_impl,
     attrs = {
         "_xcode_config": attr.label(
-            default = "@build_bazel_apple_support//xcode:version_config",
+            default = "@apple_support//xcode:version_config",
         ),
     },
     fragments = ["apple"],

--- a/xcode/available_xcodes.bzl
+++ b/xcode/available_xcodes.bzl
@@ -14,12 +14,12 @@
 
 """Implementation of the `available_xcodes` build rule."""
 
-load("@bazel_features//:features.bzl", "bazel_features")
 load(
-    "@build_bazel_apple_support//xcode/private:providers.bzl",
+    "@apple_support//xcode/private:providers.bzl",
     "AvailableXcodesInfo",
     "XcodeVersionRuleInfo",
 )
+load("@bazel_features//:features.bzl", "bazel_features")
 
 visibility("public")
 

--- a/xcode/xcode_config.bzl
+++ b/xcode/xcode_config.bzl
@@ -14,17 +14,17 @@
 
 """Implementation of the `xcode_config` build rule."""
 
-load("@bazel_features//:features.bzl", "bazel_features")
-load("@build_bazel_apple_support//build_settings:build_settings.bzl", "read_possibly_native_flag")
+load("@apple_support//build_settings:build_settings.bzl", "read_possibly_native_flag")
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeVersionPropertiesInfo",
 )
 load(
-    "@build_bazel_apple_support//xcode/private:providers.bzl",
+    "@apple_support//xcode/private:providers.bzl",
     "AvailableXcodesInfo",
     "XcodeVersionRuleInfo",
 )
+load("@bazel_features//:features.bzl", "bazel_features")
 
 visibility("public")
 
@@ -174,25 +174,25 @@ version. This may not be set if `versions` is set.
             providers = [[AvailableXcodesInfo]],
         ),
         "_xcode_version": attr.label(
-            default = "@build_bazel_apple_support//xcode:version",
+            default = "@apple_support//xcode:version",
         ),
         "_experimental_prefer_mutual_xcode": attr.label(
-            default = "@build_bazel_apple_support//xcode:experimental_prefer_mutual_xcode",
+            default = "@apple_support//xcode:experimental_prefer_mutual_xcode",
         ),
         "_include_xcode_exec_requirements": attr.label(
-            default = "@build_bazel_apple_support//xcode:include_xcode_exec_requirements",
+            default = "@apple_support//xcode:include_xcode_exec_requirements",
         ),
         "_ios_minimum_os": attr.label(
-            default = "@build_bazel_apple_support//xcode:ios_minimum_os",
+            default = "@apple_support//xcode:ios_minimum_os",
         ),
         "_macos_minimum_os": attr.label(
-            default = "@build_bazel_apple_support//xcode:macos_minimum_os",
+            default = "@apple_support//xcode:macos_minimum_os",
         ),
         "_tvos_minimum_os": attr.label(
-            default = "@build_bazel_apple_support//xcode:tvos_minimum_os",
+            default = "@apple_support//xcode:tvos_minimum_os",
         ),
         "_watchos_minimum_os": attr.label(
-            default = "@build_bazel_apple_support//xcode:watchos_minimum_os",
+            default = "@apple_support//xcode:watchos_minimum_os",
         ),
     },
     doc = """\

--- a/xcode/xcode_config_resolver.bzl
+++ b/xcode/xcode_config_resolver.bzl
@@ -15,11 +15,11 @@
 """Implementation of the `xcode_config_resolver` build rule."""
 
 load(
-    "@build_bazel_apple_support//build_settings:build_settings.bzl",
+    "@apple_support//build_settings:build_settings.bzl",
     "read_possibly_native_flag",
 )
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeVersionPropertiesInfo",
 )
 
@@ -93,12 +93,12 @@ def _properties_from_legacy_xcode_config(xcode_version_config):
 # field and the Starlark flag is handled automatically by the implementation of
 # this rule. When the native fragment is removed, it is assumed that an alias
 # will be in place to propagate the --xcode_version_config value to the Starlark
-# @build_bazel_apple_support//xcode:starlark_version_config flag.
+# @apple_support//xcode:starlark_version_config flag.
 xcode_config_resolver = rule(
     implementation = _xcode_config_resolver_impl,
     attrs = {
         "_xcode_version_config": attr.label(
-            default = "@build_bazel_apple_support//xcode:starlark_version_config",
+            default = "@apple_support//xcode:starlark_version_config",
         ),
         "_xcode_version_config_native": attr.label(
             default = configuration_field(

--- a/xcode/xcode_configure.bzl
+++ b/xcode/xcode_configure.bzl
@@ -94,7 +94,7 @@ def _xcode_version_output(repository_ctx, name, version, aliases, developer_dir,
     return build_contents
 
 VERSION_CONFIG_STUB = """
-load("@build_bazel_apple_support//xcode:xcode_config.bzl", "xcode_config")
+load("@apple_support//xcode:xcode_config.bzl", "xcode_config")
 xcode_config(name = 'host_xcodes')
 """
 
@@ -234,9 +234,9 @@ def _darwin_build_file(repository_ctx):
     default_xcode_target = ""
     target_names = []
     buildcontents = """
-load("@build_bazel_apple_support//xcode:xcode_config.bzl", "xcode_config")
-load("@build_bazel_apple_support//xcode:available_xcodes.bzl", "available_xcodes")
-load("@build_bazel_apple_support//xcode:xcode_version.bzl", "xcode_version")
+load("@apple_support//xcode:xcode_config.bzl", "xcode_config")
+load("@apple_support//xcode:available_xcodes.bzl", "available_xcodes")
+load("@apple_support//xcode:xcode_version.bzl", "xcode_version")
 """
 
     for toolchain in toolchains:

--- a/xcode/xcode_sdk_variant.bzl
+++ b/xcode/xcode_sdk_variant.bzl
@@ -15,7 +15,7 @@
 """Implementation of the `xcode_sdk_variant` build rule."""
 
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeSdkVariantInfo",
 )
 

--- a/xcode/xcode_version.bzl
+++ b/xcode/xcode_version.bzl
@@ -14,16 +14,16 @@
 
 """Implementation of the `xcode_version` build rule."""
 
-load("@bazel_features//:features.bzl", "bazel_features")
 load(
-    "@build_bazel_apple_support//xcode:providers.bzl",
+    "@apple_support//xcode:providers.bzl",
     "XcodeSdkVariantInfo",
     "XcodeVersionPropertiesInfo",
 )
 load(
-    "@build_bazel_apple_support//xcode/private:providers.bzl",
+    "@apple_support//xcode/private:providers.bzl",
     "XcodeVersionRuleInfo",
 )
+load("@bazel_features//:features.bzl", "bazel_features")
 
 visibility("public")
 


### PR DESCRIPTION
We no longer need this.