### PR TITLE
Fix releases

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,5 +1,5 @@
 matrix:
-  bazel: ["7.x", "8.x", "9.x"]
+  bazel: ["7.x", "8.x", "9.x", "rolling"]
 
 tasks:
   verify_targets:
@@ -13,9 +13,7 @@ bcr_test_module:
   module_path: "."
 
   matrix:
-    # TODO: Enabling `rolling` releases when we fix
-    # transition outputs [//command_line_option:ios_signing_cert_name] do not correspond to valid settings
-    bazel: ["7.x", "8.x", "9.x"]
+    bazel: ["7.x", "8.x", "9.x", "rolling"]
 
   tasks:
     run_tests:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
 *.plist text eol=lf
-
-test export-ignore

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 bazel_dep(name = "bazel_features", version = "1.27.0")
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "platforms", version = "0.0.9")
 bazel_dep(name = "rules_cc", version = "0.2.15")
 


### PR DESCRIPTION
BCR uses the tests dir so we can just keep it in the archives, it's
small enough anyways. We've fixed upstream compat as well.

This requires updating skylib for the `scope` attr
