### PR TITLE
Remove _allowlist_function_transition

### DIFF
--- a/rules/universal_binary.bzl
+++ b/rules/universal_binary.bzl
@@ -67,9 +67,6 @@ universal_binary = rule(
                     doc = "Target to generate a 'fat' binary from.",
                     mandatory = True,
                 ),
-                "_allowlist_function_transition": attr.label(
-                    default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-                ),
             },
     doc = """
 This rule produces a multi-architecture ("fat") binary targeting Apple macOS

--- a/test/rules/apple_verification_test.bzl
+++ b/test/rules/apple_verification_test.bzl
@@ -161,9 +161,6 @@ specified.
 Script containing the verification code.
 """,
         ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
         "_xcode_config": attr.label(
             default = configuration_field(
                 name = "xcode_config_label",

--- a/test/starlark_apple_binary.bzl
+++ b/test/starlark_apple_binary.bzl
@@ -76,9 +76,6 @@ starlark_apple_binary = rule(
             cfg = apple_platform_split_transition,
             default = "//test:default_cc_toolchain_forwarder",
         ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
     fragments = ["apple", "objc", "cpp", "j2objc"],
     implementation = _starlark_apple_binary_impl,

--- a/test/starlark_apple_static_library.bzl
+++ b/test/starlark_apple_static_library.bzl
@@ -86,9 +86,6 @@ starlark_apple_static_library = rule(
             cfg = apple_platform_split_transition,
             default = "//test:default_cc_toolchain_forwarder",
         ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
     fragments = ["apple", "objc", "cpp"],
 )

--- a/test/universal_binary_test.bzl
+++ b/test/universal_binary_test.bzl
@@ -104,9 +104,6 @@ A list of symbols that should appear in the binary file specified in
             doc = "The binary whose contents are to be verified.",
             cfg = universal_binary_test_transition,
         ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
-        ),
     },
     fragments = ["apple"],
     implementation = _universal_binary_test_impl,


### PR DESCRIPTION
This hasn't been necessary since at least 7.x
