### PR TITLE
Add rules based toolchain feature injection

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,7 +16,7 @@ x_defaults:
     build_flags:
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
     test_flags:
-      - "--test_tag_filters=-skipci"
+      - "--test_tag_filters=-skipci,-requires_rules_based_toolchain"
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
 
   linux_common: &linux_common
@@ -31,6 +31,7 @@ x_defaults:
     build_flags:
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
     test_flags:
+      - "--test_tag_filters=-requires_rules_based_toolchain"
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
 
   windows_common: &windows_common
@@ -43,6 +44,7 @@ x_defaults:
     build_flags:
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
     test_flags:
+      - "--test_tag_filters=-requires_rules_based_toolchain"
       - "--repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=0"
 
 tasks:

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -360,7 +360,10 @@ def compiling_test_suite(name):
 
     extra_enabled_features_order_test(
         name = "{}_extra_enabled_features_order_test".format(name),
-        tags = [name],
+        tags = [
+            name,
+            "requires_rules_based_toolchain",
+        ],
         expected_argv = [
             "-DCOPTS_ENV=1",
             "-DFROM_EXTRA_ENABLED_FEATURE=1",
@@ -372,7 +375,10 @@ def compiling_test_suite(name):
 
     extra_known_features_test(
         name = "{}_extra_known_features_test".format(name),
-        tags = [name],
+        tags = [
+            name,
+            "requires_rules_based_toolchain",
+        ],
         expected_argv = [
             "-DFROM_EXTRA_KNOWN_FEATURE=1",
         ],

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -1,6 +1,8 @@
 """Tests for compilation behavior."""
 
 load("@bazel_features//:features.bzl", "bazel_features")
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load(
     "//test/rules:action_command_line_test.bzl",
     "make_action_command_line_test_rule",
@@ -15,6 +17,20 @@ copt_order_test = make_action_command_line_test_rule(
         "//command_line_option:cxxopt": ["-DFROM_CXX_FLAG=1"],
         "//command_line_option:objccopt": ["-DFROM_OBJCCOPTS_FLAG=1"],
         "//command_line_option:process_headers_in_dependencies": "true",
+    },
+)
+
+extra_enabled_features_order_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        str(Label("//toolchain:extra_enabled_features")): str(Label("//test:compiling_extra_enabled_feature")),
+    },
+)
+
+extra_known_features_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": ["apple_support_test_extra_known_feature"],
+        str(Label("//toolchain:extra_known_features")): str(Label("//test:compiling_extra_known_feature")),
     },
 )
 
@@ -77,6 +93,32 @@ def compiling_test_suite(name):
     Args:
         name: The name to be included in test names and tags.
     """
+    cc_args(
+        name = "{}_extra_enabled_feature_args".format(name),
+        actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+        args = ["-DFROM_EXTRA_ENABLED_FEATURE=1"],
+    )
+
+    cc_feature(
+        name = "{}_extra_enabled_feature".format(name),
+        feature_name = "apple_support_test_extra_enabled_feature",
+        args = [":{}_extra_enabled_feature_args".format(name)],
+        visibility = ["//visibility:public"],
+    )
+
+    cc_args(
+        name = "{}_extra_known_feature_args".format(name),
+        actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+        args = ["-DFROM_EXTRA_KNOWN_FEATURE=1"],
+    )
+
+    cc_feature(
+        name = "{}_extra_known_feature".format(name),
+        feature_name = "apple_support_test_extra_known_feature",
+        args = [":{}_extra_known_feature_args".format(name)],
+        visibility = ["//visibility:public"],
+    )
+
     default_test(
         name = "{}_default_apple_macos_compile_test".format(name),
         tags = [name],
@@ -311,6 +353,28 @@ def compiling_test_suite(name):
             "-DFROM_COPTS_FLAG=1",
             "-DFROM_BUILD_COPTS=1",
             "-D__DATE__=\"redacted\"",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_lib",
+    )
+
+    extra_enabled_features_order_test(
+        name = "{}_extra_enabled_features_order_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-DCOPTS_ENV=1",
+            "-DFROM_EXTRA_ENABLED_FEATURE=1",
+            "-DFROM_BUILD_COPTS=1",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_lib",
+    )
+
+    extra_known_features_test(
+        name = "{}_extra_known_features_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-DFROM_EXTRA_KNOWN_FEATURE=1",
         ],
         mnemonic = "CppCompile",
         target_under_test = "//test/test_data:cc_lib",

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc/toolchains:args_list.bzl", "cc_args_list")
 load("@rules_cc//cc/toolchains:artifacts.bzl", "cc_artifact_name_pattern")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:legacy_tool.bzl", "cc_legacy_tool")
 load("@rules_cc//cc/toolchains:make_variable.bzl", "cc_make_variable")
 load("@rules_cc//cc/toolchains:nested_args.bzl", "cc_nested_args")
@@ -33,6 +34,23 @@ ENABLED_MARKERS = [
     "set_soname",
 ] + (
     ["gcc_quoting_for_param_files"] if bazel_features.cc.fixed_dsym_path_quoting else []
+)
+
+cc_feature_set(
+    name = "_empty_feature_set",
+    all_of = [],
+)
+
+label_flag(
+    name = "extra_enabled_features",
+    build_setting_default = ":_empty_feature_set",
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "extra_known_features",
+    build_setting_default = ":_empty_feature_set",
+    visibility = ["//visibility:public"],
 )
 
 # TODO: See if we really need this one
@@ -856,6 +874,7 @@ cc_toolchain(
         ":dead_strip_wrapper",
         ":apply_implicit_frameworks",
         ":link_cocoa_wrapper",
+        ":extra_enabled_features",
         ":user_compile_flags",  # TODO: Switch to compile_flags:feature if ordering isn't an issue
         ":unfiltered_compile_flags",
         ":__compiler_input_flags_without_header_parsing",
@@ -898,6 +917,7 @@ cc_toolchain(
         "//toolchain/pgo:autofdo",
         "//toolchain/pgo:fdo_optimize",
         "@apple_support_toolchain_env//:off_by_default_layering_check_known_features",
+        ":extra_known_features",
         "@rules_cc//cc/toolchains/args/layering_check:use_module_maps",  # TODO: https://github.com/bazelbuild/rules_cc/pull/657
     ] + select({
         "@platforms//os:macos": [


### PR DESCRIPTION
With this users can set
`--@apple_support//toolchain:extra_known_features` and
`--@apple_support//toolchain:extra_enabled_features` to a
`cc_feature_set` target in order to inject their own features.
