### PR TITLE
Add parse_headers_as_c support

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -208,15 +208,24 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 flag_groups = [
                     flag_group(
                         flags = [
-                            # Note: This treats all headers as C++ headers, which may lead to
-                            # parsing failures for C headers that are not valid C++.
-                            # For such headers, use features = ["-parse_headers"] to selectively
-                            # disable parsing.
                             "-xc++-header",
                             "-fsyntax-only",
                         ],
                     ),
                 ],
+                with_features = [with_feature_set(not_features = ["parse_headers_as_c"])],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_header_parsing],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-xc-header",
+                            "-fsyntax-only",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(features = ["parse_headers_as_c"])],
             ),
         ],
         env_sets = [
@@ -1930,10 +1939,18 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 ] if ctx.attr.conly_flags else []),
             ),
             flag_set(
+                actions = [ACTION_NAMES.cpp_header_parsing],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.conly_flags,
+                    ),
+                ] if ctx.attr.conly_flags else []),
+                with_features = [with_feature_set(features = ["parse_headers_as_c"])],
+            ),
+            flag_set(
                 actions = [
                     ACTION_NAMES.linkstamp_compile,
                     ACTION_NAMES.cpp_compile,
-                    ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.cpp_module_compile,
                 ],
                 flag_groups = ([
@@ -1941,6 +1958,15 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                         flags = ctx.attr.cxx_flags,
                     ),
                 ] if ctx.attr.cxx_flags else []),
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_header_parsing],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.cxx_flags,
+                    ),
+                ] if ctx.attr.cxx_flags else []),
+                with_features = [with_feature_set(not_features = ["parse_headers_as_c"])],
             ),
             flag_set(
                 actions = [
@@ -2294,6 +2320,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         feature(name = "only_doth_headers_in_module_maps"),
         feature(name = "opt"),
         feature(name = "parse_headers"),
+        feature(name = "parse_headers_as_c"),
         feature(name = "no_dotd_file"),
         feature(name = "sanitize_pwd", enabled = True),
         feature(name = "set_soname", enabled = True),

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -408,6 +408,29 @@ def compiling_test_suite(name):
         target_under_test = "//test/header_parsing:valid_header",
     )
 
+    copt_order_test(
+        name = "{}_header_parsing_as_c_copt_order_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-xc-header",
+            "-fsyntax-only",
+            "-O2",  # From --compilation_mode=opt
+            "-isysroot",
+            "__BAZEL_XCODE_SDKROOT__",
+            "-DFROM_COPTS_FLAG=1",
+            "-D__DATE__=\"redacted\"",
+            "test/header_parsing/c_only_header.h",
+            "-o",
+            "$(BIN_DIR)/test/header_parsing/_objs/c_only_header/c_only_header.h.processed",
+        ],
+        not_expected_argv = [
+            "-c",  # Produces a clang warning since we don't compile anything in this action
+            "-xc++-header",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/header_parsing:c_only_header",
+    )
+
     default_test(
         name = "{}_dependency_file_test".format(name),
         tags = [name],

--- a/test/compiling_tests.bzl
+++ b/test/compiling_tests.bzl
@@ -13,6 +13,7 @@ default_test = make_action_command_line_test_rule()
 copt_order_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:conlyopt": ["-DFROM_CONLY_FLAG=1"],
         "//command_line_option:copt": ["-DFROM_COPTS_FLAG=1"],
         "//command_line_option:cxxopt": ["-DFROM_CXX_FLAG=1"],
         "//command_line_option:objccopt": ["-DFROM_OBJCCOPTS_FLAG=1"],
@@ -395,7 +396,11 @@ def compiling_test_suite(name):
             "-O2",  # From --compilation_mode=opt
             "-isysroot",
             "__BAZEL_XCODE_SDKROOT__",
+            "-DCOPTS_ENV=1",
+            "-std=c++17",
+            "-DCXXOPTS_ENV=1",
             "-DFROM_COPTS_FLAG=1",
+            "-DFROM_CXX_FLAG=1",
             "-D__DATE__=\"redacted\"",
             "test/header_parsing/valid_header.h",
             "-o",
@@ -403,6 +408,8 @@ def compiling_test_suite(name):
         ],
         not_expected_argv = [
             "-c",  # Produces a clang warning since we don't compile anything in this action
+            "-DCONLY_ENV=1",
+            "-DFROM_CONLY_FLAG=1",
         ],
         mnemonic = "CppCompile",
         target_under_test = "//test/header_parsing:valid_header",
@@ -417,6 +424,8 @@ def compiling_test_suite(name):
             "-O2",  # From --compilation_mode=opt
             "-isysroot",
             "__BAZEL_XCODE_SDKROOT__",
+            "-DCOPTS_ENV=1",
+            "-DCONLY_ENV=1",
             "-DFROM_COPTS_FLAG=1",
             "-D__DATE__=\"redacted\"",
             "test/header_parsing/c_only_header.h",
@@ -426,6 +435,8 @@ def compiling_test_suite(name):
         not_expected_argv = [
             "-c",  # Produces a clang warning since we don't compile anything in this action
             "-xc++-header",
+            "-std=c++17",
+            "-DCXXOPTS_ENV=1",
         ],
         mnemonic = "CppCompile",
         target_under_test = "//test/header_parsing:c_only_header",

--- a/test/header_parsing/BUILD
+++ b/test/header_parsing/BUILD
@@ -22,6 +22,19 @@ cc_library(
 )
 
 cc_library(
+    name = "c_only_header_without_parse_headers_as_c",
+    hdrs = ["c_only_header.h"],
+    tags = ["manual"],
+)
+
+cc_library(
+    name = "c_only_header",
+    hdrs = ["c_only_header.h"],
+    features = ["parse_headers_as_c"],
+    visibility = ["//test:__subpackages__"],
+)
+
+cc_library(
     name = "valid_header",
     hdrs = ["valid_header.h"],
     visibility = ["//test:__subpackages__"],
@@ -35,6 +48,7 @@ objc_library(
 build_test(
     name = "test",
     targets = [
+        ":c_only_header",
         ":invalid_header_feature_disabled",
         ":valid_header",
         ":valid_header_objc",

--- a/test/header_parsing/c_only_header.h
+++ b/test/header_parsing/c_only_header.h
@@ -1,0 +1,5 @@
+#ifdef __cplusplus
+#error "expected C header parsing"
+#endif
+
+void c_only_header(void);

--- a/test/shell/header_parsing_test.sh
+++ b/test/shell/header_parsing_test.sh
@@ -19,4 +19,13 @@ function test_bad_header_parsing_objc() {
   expect_log "test/header_parsing/invalid_header.h:2:1: error: unknown type name 'uint8_t'"
 }
 
+function test_header_parsing_as_c() {
+  bazel_cmd build --process_headers_in_dependencies -- //test/header_parsing:c_only_header &>"$TEST_log"
+}
+
+function test_c_header_without_parse_headers_as_c() {
+  ! bazel_cmd build --process_headers_in_dependencies -- //test/header_parsing:c_only_header_without_parse_headers_as_c &> "$TEST_log" || fail "Expected build failure"
+  expect_log 'test/header_parsing/c_only_header.h:2:2: error: "expected C header parsing"'
+}
+
 run_suite "header_parsing tests"

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3722,8 +3792,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3745,6 +3844,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4962,6 +5092,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3726,8 +3796,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3749,6 +3848,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4966,6 +5096,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3726,8 +3796,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3749,6 +3848,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4966,6 +5096,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3724,8 +3794,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3747,6 +3846,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4942,6 +5072,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3724,8 +3794,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3747,6 +3846,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4942,6 +5072,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3751,8 +3821,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3774,6 +3873,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4969,6 +5099,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3751,8 +3821,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3774,6 +3873,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4969,6 +5099,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3698,8 +3768,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3721,6 +3820,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4916,6 +5046,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3725,8 +3795,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3748,6 +3847,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4943,6 +5073,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3725,8 +3795,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3748,6 +3847,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4943,6 +5073,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3697,8 +3767,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3720,6 +3819,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4915,6 +5045,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3724,8 +3794,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3747,6 +3846,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4942,6 +5072,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3725,8 +3795,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3748,6 +3847,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4943,6 +5073,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3698,8 +3768,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3721,6 +3820,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4916,6 +5046,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3698,8 +3768,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3721,6 +3820,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4916,6 +5046,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3698,8 +3768,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3721,6 +3820,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4916,6 +5046,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -852,7 +852,38 @@
             }
           ],
           "type_name": "env_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "env_entries": [
+            {
+              "expand_if_available": "output_file",
+              "key": "HEADER_PARSING_OUTPUT",
+              "type_name": "env_entry",
+              "value": "%{output_file}"
+            }
+          ],
+          "type_name": "env_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "flag_sets": [
@@ -877,7 +908,46 @@
             }
           ],
           "type_name": "flag_set",
-          "with_features": []
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "output_file",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-xc-header",
+                "-fsyntax-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -3725,8 +3795,37 @@
         },
         {
           "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-DCONLY_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "parse_headers_as_c"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "c++-compile",
-            "c++-header-parsing",
             "c++-module-compile",
             "linkstamp-compile"
           ],
@@ -3748,6 +3847,37 @@
           ],
           "type_name": "flag_set",
           "with_features": []
+        },
+        {
+          "actions": [
+            "c++-header-parsing"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-std=c++17",
+                "-DCXXOPTS_ENV=1"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [],
+              "not_features": [
+                "parse_headers_as_c"
+              ],
+              "type_name": "with_feature_set"
+            }
+          ]
         }
       ],
       "implies": [],
@@ -4943,6 +5073,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "parse_headers",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": false,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "parse_headers_as_c",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -24,6 +24,7 @@ MARKER_FEATURES = [
     "no_legacy_features",
     "only_doth_headers_in_module_maps",
     "parse_headers",
+    "parse_headers_as_c",
     "sanitize_pwd",
     "set_soname",
 ]
@@ -634,20 +635,50 @@ enableable_feature(
     }),
 )
 
-negatable_feature(
-    name = "__header_parsing_flags",
+cc_feature_constraint(
+    name = "parse_headers_as_c_enabled",
+    all_of = [":parse_headers_as_c"],
+    visibility = ["//visibility:public"],
+)
+
+cc_feature_constraint(
+    name = "not_parse_headers_as_c",
+    none_of = [":parse_headers_as_c"],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "_header_parsing_flags_cpp_args",
     actions = ["@rules_cc//cc/toolchains/actions:cpp_header_parsing"],
     args = [
-        # Note: This treats all headers as C++ headers, which may lead to
-        # parsing failures for C headers that are not valid C++.
-        # For such headers, use features = ["-parse_headers"] to selectively
-        # disable parsing.
         "-xc++-header",
         "-fsyntax-only",
     ],
     env = {"HEADER_PARSING_OUTPUT": "{output_file}"},
     format = {"output_file": "@rules_cc//cc/toolchains/variables:output_file"},
+    requires_any_of = [":not_parse_headers_as_c"],
     requires_not_none = "@rules_cc//cc/toolchains/variables:output_file",
+)
+
+cc_args(
+    name = "_header_parsing_flags_c_args",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_header_parsing"],
+    args = [
+        "-xc-header",
+        "-fsyntax-only",
+    ],
+    env = {"HEADER_PARSING_OUTPUT": "{output_file}"},
+    format = {"output_file": "@rules_cc//cc/toolchains/variables:output_file"},
+    requires_any_of = [":parse_headers_as_c_enabled"],
+    requires_not_none = "@rules_cc//cc/toolchains/variables:output_file",
+)
+
+negatable_feature(
+    name = "__header_parsing_flags",
+    custom_args = [
+        ":_header_parsing_flags_cpp_args",
+        ":_header_parsing_flags_c_args",
+    ],
 )
 
 cc_artifact_name_pattern(

--- a/toolchain/toolchain_env.bzl
+++ b/toolchain/toolchain_env.bzl
@@ -151,7 +151,9 @@ cc_feature(
     args = [
         ":copts",
         ":conlyopts",
+        ":conlyopts_for_header_parsing",
         ":cxxopts",
+        ":cxxopts_for_header_parsing",
     ],
 )
 
@@ -168,15 +170,28 @@ cc_args(
 )
 
 cc_args(
+    name = "conlyopts_for_header_parsing",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_header_parsing"],
+    args = [{conly_opts}],
+    requires_any_of = ["@apple_support//toolchain:parse_headers_as_c_enabled"],
+)
+
+cc_args(
     name = "cxxopts",
     actions = [
         # TODO: Should more actions be here?
         "@rules_cc//cc/toolchains/actions:cpp_compile",
-        "@rules_cc//cc/toolchains/actions:cpp_header_parsing",
         "@rules_cc//cc/toolchains/actions:cpp_module_compile",
         "@rules_cc//cc/toolchains/actions:linkstamp_compile",
     ],
     args = [{cxx_opts}],
+)
+
+cc_args(
+    name = "cxxopts_for_header_parsing",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_header_parsing"],
+    args = [{cxx_opts}],
+    requires_any_of = ["@apple_support//toolchain:not_parse_headers_as_c"],
 )
 
 cc_feature(


### PR DESCRIPTION
This allows users to use parse_headers when the headers don't support
C++. This is opt in on targets that need it.

Mirrored from https://github.com/bazelbuild/rules_cc/pull/685
