### PR TITLE
Update the default SDK versions

### DIFF
--- a/xcode/xcode_config.bzl
+++ b/xcode/xcode_config.bzl
@@ -77,12 +77,17 @@ def _xcode_config_impl(ctx):
         )
         availability = "UNKNOWN"
 
+    # These default SDK versions correspond to the minimum supported versions of
+    # the OSes by Xcode 27. They won't often be used because nearly all builds
+    # will specify their own minimum OS version in a bundling target or on the
+    # command line, but these defaults are ensured to be high enough that they
+    # won't immediately cause build failures with modern toolchains.
     # TODO: Remove `getattr` once we no longer support a version of Bazel with
     # `apple_fragment.*_sdk_version_flag`
-    ios_sdk_version = _sdk_version_flag(apple_fragment, "ios_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_ios_sdk_version, "8.4")
-    macos_sdk_version = _sdk_version_flag(apple_fragment, "macos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_macos_sdk_version, "10.11")
-    tvos_sdk_version = _sdk_version_flag(apple_fragment, "tvos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_tvos_sdk_version, "9.0")
-    watchos_sdk_version = _sdk_version_flag(apple_fragment, "watchos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_watchos_sdk_version, "2.0")
+    ios_sdk_version = _sdk_version_flag(apple_fragment, "ios_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_ios_sdk_version, "15.0")
+    macos_sdk_version = _sdk_version_flag(apple_fragment, "macos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_macos_sdk_version, "12.0")
+    tvos_sdk_version = _sdk_version_flag(apple_fragment, "tvos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_tvos_sdk_version, "15.0")
+    watchos_sdk_version = _sdk_version_flag(apple_fragment, "watchos_sdk_version_flag") or _dotted_version_or_default(xcode_version_properties.default_watchos_sdk_version, "9.0")
     visionos_sdk_version = _dotted_version_or_default(xcode_version_properties.default_visionos_sdk_version, "1.0")
 
     ios_minimum_os = read_possibly_native_flag(ctx, "ios_minimum_os") or ios_sdk_version


### PR DESCRIPTION
These feed into the default minimum OS versions if they aren't
specified. These versions were picked to be compatible with the new
minimums required by Xcode 27.

(cherry picked from commit 3fb5fe6e78344e4dd450de6a5d5ae776c27358c2)
