### PR TITLE
Make sanitizer builds respect -c for -g*

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2153,18 +2153,11 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-fno-omit-frame-pointer",
-                            "-fno-sanitize-recover=all",
-                        ],
-                    ),
-                ],
+                flag_groups = [flag_group(flags = ["-gline-tables-only"])],
                 with_features = [
-                    with_feature_set(features = ["asan"]),
-                    with_feature_set(features = ["tsan"]),
-                    with_feature_set(features = ["ubsan"]),
+                    with_feature_set(features = ["asan", "fastbuild"]),
+                    with_feature_set(features = ["tsan", "fastbuild"]),
+                    with_feature_set(features = ["ubsan", "fastbuild"]),
                 ],
             ),
             flag_set(
@@ -2174,11 +2167,11 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     ACTION_NAMES.objc_compile,
                     ACTION_NAMES.objcpp_compile,
                 ],
-                flag_groups = [flag_group(flags = ["-gline-tables-only"])],
+                flag_groups = [flag_group(flags = ["-fno-sanitize-recover=all"])],
                 with_features = [
-                    with_feature_set(features = ["asan", "fastbuild"]),
-                    with_feature_set(features = ["tsan", "fastbuild"]),
-                    with_feature_set(features = ["ubsan", "fastbuild"]),
+                    with_feature_set(features = ["asan"]),
+                    with_feature_set(features = ["tsan"]),
+                    with_feature_set(features = ["ubsan"]),
                 ],
             ),
         ],

--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -2156,7 +2156,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 flag_groups = [
                     flag_group(
                         flags = [
-                            "-gline-tables-only",
                             "-fno-omit-frame-pointer",
                             "-fno-sanitize-recover=all",
                         ],
@@ -2166,6 +2165,20 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                     with_feature_set(features = ["asan"]),
                     with_feature_set(features = ["tsan"]),
                     with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["-gline-tables-only"])],
+                with_features = [
+                    with_feature_set(features = ["asan", "fastbuild"]),
+                    with_feature_set(features = ["tsan", "fastbuild"]),
+                    with_feature_set(features = ["ubsan", "fastbuild"]),
                 ],
             ),
         ],

--- a/test/sanitizer_tests.bzl
+++ b/test/sanitizer_tests.bzl
@@ -77,9 +77,9 @@ def sanitizer_test_suite(name):
         name = "{}_asan_cc_compile_test".format(name),
         tags = [name],
         expected_argv = [
+            "-fno-omit-frame-pointer",
             "-fsanitize=address",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -95,11 +95,11 @@ def sanitizer_test_suite(name):
         name = "{}_asan_dbg_cc_compile_test".format(name),
         tags = [name],
         expected_argv = [
+            "-fno-omit-frame-pointer",
             "-O0",
             "-DDEBUG",
             "-g",
             "-fsanitize=address",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -115,9 +115,9 @@ def sanitizer_test_suite(name):
         name = "{}_asan_objc_compile_test".format(name),
         tags = [name],
         expected_argv = [
+            "-fno-omit-frame-pointer",
             "-fsanitize=address",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -154,9 +154,9 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-fsanitize=thread",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -172,11 +172,11 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-O0",
             "-DDEBUG",
             "-g",
             "-fsanitize=thread",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -192,9 +192,9 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-fsanitize=thread",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -230,9 +230,9 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-fsanitize=undefined",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -248,11 +248,11 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-O0",
             "-DDEBUG",
             "-g",
             "-fsanitize=undefined",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [
@@ -268,9 +268,9 @@ def sanitizer_test_suite(name):
         tags = [name],
         expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-fno-omit-frame-pointer",
             "-fsanitize=undefined",
             "-gline-tables-only",
-            "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
         not_expected_argv = [

--- a/test/sanitizer_tests.bzl
+++ b/test/sanitizer_tests.bzl
@@ -9,18 +9,42 @@ default_test = make_action_command_line_test_rule()
 
 asan_test = make_action_command_line_test_rule(
     config_settings = {
+        "//command_line_option:compilation_mode": "fastbuild",
+        "//command_line_option:features": ["asan"],
+    },
+)
+
+asan_dbg_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
         "//command_line_option:features": ["asan"],
     },
 )
 
 tsan_test = make_action_command_line_test_rule(
     config_settings = {
+        "//command_line_option:compilation_mode": "fastbuild",
+        "//command_line_option:features": ["tsan"],
+    },
+)
+
+tsan_dbg_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
         "//command_line_option:features": ["tsan"],
     },
 )
 
 ubsan_test = make_action_command_line_test_rule(
     config_settings = {
+        "//command_line_option:compilation_mode": "fastbuild",
+        "//command_line_option:features": ["ubsan"],
+    },
+)
+
+ubsan_dbg_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
         "//command_line_option:features": ["ubsan"],
     },
 )
@@ -60,6 +84,28 @@ def sanitizer_test_suite(name):
         ],
         not_expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-g",
+            "-g0",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_main",
+    )
+
+    asan_dbg_test(
+        name = "{}_asan_dbg_cc_compile_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-O0",
+            "-DDEBUG",
+            "-g",
+            "-fsanitize=address",
+            "-fno-omit-frame-pointer",
+            "-fno-sanitize-recover=all",
+        ],
+        not_expected_argv = [
+            "-D_FORTIFY_SOURCE=1",
+            "-gline-tables-only",
+            "-g0",
         ],
         mnemonic = "CppCompile",
         target_under_test = "//test/test_data:cc_main",
@@ -76,6 +122,8 @@ def sanitizer_test_suite(name):
         ],
         not_expected_argv = [
             "-D_FORTIFY_SOURCE=1",
+            "-g",
+            "-g0",
         ],
         mnemonic = "ObjcCompile",
         target_under_test = "//test/test_data:objc_lib",
@@ -111,6 +159,30 @@ def sanitizer_test_suite(name):
             "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
+        not_expected_argv = [
+            "-g",
+            "-g0",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_main",
+    )
+
+    tsan_dbg_test(
+        name = "{}_tsan_dbg_cc_compile_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-D_FORTIFY_SOURCE=1",
+            "-O0",
+            "-DDEBUG",
+            "-g",
+            "-fsanitize=thread",
+            "-fno-omit-frame-pointer",
+            "-fno-sanitize-recover=all",
+        ],
+        not_expected_argv = [
+            "-gline-tables-only",
+            "-g0",
+        ],
         mnemonic = "CppCompile",
         target_under_test = "//test/test_data:cc_main",
     )
@@ -124,6 +196,10 @@ def sanitizer_test_suite(name):
             "-gline-tables-only",
             "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
+        ],
+        not_expected_argv = [
+            "-g",
+            "-g0",
         ],
         mnemonic = "ObjcCompile",
         target_under_test = "//test/test_data:objc_lib",
@@ -159,6 +235,30 @@ def sanitizer_test_suite(name):
             "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
         ],
+        not_expected_argv = [
+            "-g",
+            "-g0",
+        ],
+        mnemonic = "CppCompile",
+        target_under_test = "//test/test_data:cc_main",
+    )
+
+    ubsan_dbg_test(
+        name = "{}_ubsan_dbg_cc_compile_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-D_FORTIFY_SOURCE=1",
+            "-O0",
+            "-DDEBUG",
+            "-g",
+            "-fsanitize=undefined",
+            "-fno-omit-frame-pointer",
+            "-fno-sanitize-recover=all",
+        ],
+        not_expected_argv = [
+            "-gline-tables-only",
+            "-g0",
+        ],
         mnemonic = "CppCompile",
         target_under_test = "//test/test_data:cc_main",
     )
@@ -172,6 +272,10 @@ def sanitizer_test_suite(name):
             "-gline-tables-only",
             "-fno-omit-frame-pointer",
             "-fno-sanitize-recover=all",
+        ],
+        not_expected_argv = [
+            "-g",
+            "-g0",
         ],
         mnemonic = "ObjcCompile",
         target_under_test = "//test/test_data:objc_lib",

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -4711,7 +4711,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -4678,7 +4678,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -4682,7 +4682,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -4715,7 +4715,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -4682,7 +4682,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -4715,7 +4715,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -4658,7 +4658,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -4691,7 +4691,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -4658,7 +4658,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -4691,7 +4691,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -4718,7 +4718,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -4685,7 +4685,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -4718,7 +4718,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -4685,7 +4685,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -4632,7 +4632,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -4665,7 +4665,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -4692,7 +4692,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -4659,7 +4659,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -4692,7 +4692,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -4659,7 +4659,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -4631,7 +4631,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -4664,7 +4664,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -4658,7 +4658,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -4691,7 +4691,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -4692,7 +4692,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -4659,7 +4659,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -4632,7 +4632,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -4665,7 +4665,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -4632,7 +4632,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -4665,7 +4665,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -4632,7 +4632,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -4665,7 +4665,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -4692,7 +4692,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],
               "iterate_over": null,

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -4659,7 +4659,39 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-gline-tables-only",
+                "-gline-tables-only"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "fastbuild"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
+            "c++-compile",
+            "c-compile",
+            "objc++-compile",
+            "objc-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
                 "-fno-omit-frame-pointer",
                 "-fno-sanitize-recover=all"
               ],

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -73,16 +73,19 @@ _LIMITED_COMPILE_ACTIONS = [
 cc_feature(
     name = "dbg",
     overrides = "@rules_cc//cc/toolchains/features:dbg",
+    visibility = ["//visibility:public"],
 )
 
 cc_feature(
     name = "fastbuild",
     overrides = "@rules_cc//cc/toolchains/features:fastbuild",
+    visibility = ["//visibility:public"],
 )
 
 cc_feature(
     name = "opt",
     overrides = "@rules_cc//cc/toolchains/features:opt",
+    visibility = ["//visibility:public"],
 )
 
 cc_feature(

--- a/toolchain/sanitizers/BUILD
+++ b/toolchain/sanitizers/BUILD
@@ -67,7 +67,6 @@ cc_args(
     name = "default_sanitizer_flags_args",
     actions = _LIMITED_COMPILE_ACTIONS,
     args = [
-        "-fno-omit-frame-pointer",
         "-fno-sanitize-recover=all",
     ],
 )

--- a/toolchain/sanitizers/BUILD
+++ b/toolchain/sanitizers/BUILD
@@ -44,7 +44,10 @@ enableable_feature(
 
 cc_feature(
     name = "default_sanitizer_flags",
-    args = [":default_sanitizer_flags_args"],
+    args = [
+        ":default_sanitizer_fastbuild_flags_args",
+        ":default_sanitizer_flags_args",
+    ],
     feature_name = "default_sanitizer_flags",
     requires_any_of = [
         ":asan",
@@ -54,10 +57,16 @@ cc_feature(
 )
 
 cc_args(
+    name = "default_sanitizer_fastbuild_flags_args",
+    actions = _LIMITED_COMPILE_ACTIONS,
+    args = ["-gline-tables-only"],
+    requires_any_of = ["//toolchain:fastbuild"],
+)
+
+cc_args(
     name = "default_sanitizer_flags_args",
     actions = _LIMITED_COMPILE_ACTIONS,
     args = [
-        "-gline-tables-only",
         "-fno-omit-frame-pointer",
         "-fno-sanitize-recover=all",
     ],


### PR DESCRIPTION
Previously for `--features=asan` you got `-gline-tables-only`. This
isn't ideal if you actually want to debug the sanitized code. Now it
respects `--compilation_mode` so with `-c dbg` you get `-g` and with
`-c fastbuild` you get `-gline-tables-only`.

This is a tiny bit weird because we don't pass any `-g` for `fastbuild`
normally.

Fixes https://github.com/bazelbuild/apple_support/issues/613
