### PR TITLE
Support hermetic developer directories in the crosstool

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -48,6 +48,21 @@ _CPP_DYNAMIC_LINK_ACTIONS = [
 _COMPILE_ACTIONS_WITHOUT_HEADER_PARSING = list(ACTION_NAME_GROUPS.all_cc_compile_actions)
 _COMPILE_ACTIONS_WITHOUT_HEADER_PARSING.remove(ACTION_NAMES.cpp_header_parsing)
 
+def _is_xcode_at_least_version(xcode_config, version):
+    """Returns True if the current Xcode version is at least the given version.
+
+    Mirrors `xcode_support.is_xcode_at_least_version`: when the Xcode version
+    is a path to a developer directory (used by hermetic toolchain setups), we
+    assume the user manages toolchain features themselves and treat it as the
+    latest Xcode.
+    """
+    current_version = xcode_config.xcode_version()
+    if not current_version:
+        return False
+    if str(current_version).startswith("/"):
+        return True
+    return current_version >= apple_common.dotted_version(version)
+
 def _sdk_version_for_platform(xcode_config, platform_type):
     if platform_type == apple_common.platform_type.ios:
         return xcode_config.sdk_version_for_platform(apple_common.platform.ios_device)
@@ -2208,9 +2223,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
     # As of Xcode 15, linker warnings are emitted if duplicate `-l` options are
     # present. Until such linkopts can be deduped by bazel itself, we disable
     # these warnings.
-    is_15_or_above = False
-    if xcode_config.xcode_version():
-        is_15_or_above = xcode_config.xcode_version() >= apple_common.dotted_version("15.0")
+    is_15_or_above = _is_xcode_at_least_version(xcode_config, "15.0")
     no_warn_duplicate_libraries_feature = feature(
         name = "no_warn_duplicate_libraries",
         enabled = "no_warn_duplicate_libraries" in ctx.features or
@@ -2230,9 +2243,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
         ],
     )
 
-    is_26_or_above = False
-    if xcode_config.xcode_version():
-        is_26_or_above = xcode_config.xcode_version() >= apple_common.dotted_version("26.0")
+    is_26_or_above = _is_xcode_at_least_version(xcode_config, "26.0")
 
     reproducible_linker_flag_feature = feature(
         name = "reproducible_linker_flag",

--- a/crosstool/osx_cc_configure.bzl
+++ b/crosstool/osx_cc_configure.bzl
@@ -147,11 +147,15 @@ def _succeeds(repository_ctx, *args):
 def _copy_file(repository_ctx, src, dest):
     repository_ctx.file(dest, content = repository_ctx.read(src))
 
-def configure_osx_toolchain(repository_ctx):
+def configure_osx_toolchain(repository_ctx, extra_include_dirs = []):
     """Configure C++ toolchain on macOS.
 
     Args:
       repository_ctx: The repository context.
+      extra_include_dirs: Additional directories to allow builtin includes
+          from, for toolchains and SDKs that live outside of the standard
+          Xcode and Command Line Tools installation directories (for example
+          hermetic toolchains vendored into external repositories).
 
     Returns:
       Whether or not configuration was successful
@@ -191,6 +195,7 @@ def configure_osx_toolchain(repository_ctx):
         features.append("reproducible_linker_flag")
 
     escaped_include_paths = _get_escaped_xcode_cxx_inc_directories(repository_ctx, xcode_toolchains)
+    escaped_include_paths += [escape_string(directory) for directory in extra_include_dirs]
     escaped_cxx_include_directories = []
     for path in escaped_include_paths:
         escaped_cxx_include_directories.append(("            \"%s\"," % path))


### PR DESCRIPTION
Two small changes needed by [hermetic_apple_toolchains](https://github.com/AttilaTheFun/hermetic_apple_toolchains), which registers verbatim Xcode.app copies inside external repositories and drives the build with a path-valued `--xcode_version` (an absolute developer directory path, which Bazel uses directly as `DEVELOPER_DIR`).

- `configure_osx_toolchain` gains an `extra_include_dirs` parameter so a wrapping repository rule can allow builtin includes from the external repository root, where the vendored Xcodes live. (Without this, headers resolved from the hermetic SDKs are flagged as undeclared inclusions, since they are outside the default /Applications and /Library include roots.)
- `cc_toolchain_config.bzl` treats a path-valued Xcode version as the latest Xcode in its two inline `>=` feature checks (`no_warn_duplicate_libraries`, `reproducible_linker_flag`) instead of failing with an unparseable dotted version.

The path-as-version semantics in the second bullet are not new — this extends an existing, Apple-contributed convention to the last place that still hard-fails on it:

- Bazel itself: a path-valued `XCODE_VERSION_OVERRIDE` is used directly as `DEVELOPER_DIR` ("Directly use version as DEVELOPER_DIR when a path is passed", [`XcodeLocalEnvProvider.java`](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java)).
- apple_support: [`xcode_support.is_xcode_at_least_version`](https://github.com/bazelbuild/apple_support/blob/master/lib/xcode_support.bzl#L92) returns `True` for path-valued versions since bazelbuild/apple_support#481 ("We're gonna assume that if the user passes Xcode as a directory, they're ok managing the features themselves, and we'll assume they're on the latest and greatest Xcode").
- rules_swift: the toolchain's [`_is_xcode_at_least_version`](https://github.com/bazelbuild/rules_swift/blob/master/swift/toolchains/xcode_swift_toolchain.bzl#L722) does the same since bazelbuild/rules_swift#1597.

The new helper in `cc_toolchain_config.bzl` mirrors those implementations; the two inline comparisons were added later (for the Xcode 15 and Xcode 26 linker flags) and never picked up the convention. Without this, analysis fails with a Starlark error when comparing the path against `apple_common.dotted_version("15.0")`.