### PR TITLE
Let consumers extend the rules-based toolchain's include allowlist

### DIFF
--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -13,6 +13,20 @@ load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load(":dynamic_toolchain_info.bzl", "dynamic_toolchain_info", "xcode_execution_info")
 load(":features.bzl", "enableable_feature", "negatable_feature")
 
+# Consumers can append an extra cc_args (for example with
+# allowlist_absolute_include_directories for hermetic Xcodes vendored into
+# external repositories) without modifying this toolchain:
+#   --@apple_support//toolchain:extra_include_directories=//your:cc_args
+label_flag(
+    name = "extra_include_directories",
+    build_setting_default = ":no_extra_include_directories",
+)
+
+cc_args(
+    name = "no_extra_include_directories",
+    actions = ["@rules_cc//cc/toolchains/actions:all_actions"],
+)
+
 MARKER_FEATURES = [
     "archive_param_file",
     "compile_all_modules",
@@ -848,6 +862,7 @@ cc_toolchain(
     name = "toolchain",
     args = [
         "@apple_support_toolchain_env//:include_directories_from_xcode",
+        ":extra_include_directories",
     ] + select({
         ":no_xcode_version": [":clt_env"],
         "//conditions:default": [":xcode_env"],


### PR DESCRIPTION
Follow-up to the review feedback on #616 — migrating to the rules-based toolchain worked (thanks for the pointer, it removed almost everything we needed from that PR), with one remaining gap: include validation for SDK/toolchain headers that live outside the standard install locations.

This adds an `extra_include_directories` label_flag (default: an empty `cc_args`) appended to the toolchain's args. Consumers whose developer directories live elsewhere — for example verbatim Xcode.app copies vendored into external repositories ([hermetic_apple_toolchains](https://github.com/AttilaTheFun/hermetic_apple_toolchains)) — point the flag at a `cc_args` with `allowlist_absolute_include_directories` entries for those locations:

```
build --@apple_support//toolchain:extra_include_directories=//your:cc_args
```

Being analysis-time and additive, this lets the allowlist stay as narrow as the specific developer directories (avoiding the overly broad builtin include entries from the previous approach, which per bazelbuild/bazel#29613 can silently break dependency tracking for anything under the output base).

Verified with hermetic Xcode 26.5 and 27 beta copies in external repositories: builds, simulator runs, and rules_xcodeproj-generated projects all pass with the flag supplying the vendored developer dirs; without it, compiles of anything touching the SDK fail include validation.