### PR TITLE
Adapt rules based toolchain to work on other platforms

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -25,6 +25,7 @@ x_defaults:
       - "//test/test_data:multi_arch_cc_binary"
     test_targets:
       - "//tools/http_dmg/..."
+      - "//test/linux_toolchain/..."
 
   linux_common_toolchain_off: &linux_common_toolchain_off
     <<: *linux_common

--- a/.bazelrc
+++ b/.bazelrc
@@ -5,8 +5,8 @@ common --repo_env=APPLE_SUPPORT_RULES_BASED_TOOLCHAIN=1
 common --repo_env=BAZEL_CONLYOPTS=-DCONLY_ENV=1
 common --repo_env=BAZEL_COPTS=-DCOPTS_ENV=1
 common --repo_env=BAZEL_CXXOPTS="-std=c++17:-DCXXOPTS_ENV=1"
-# Platform specific linker flag
-common:macos --repo_env=BAZEL_LINKOPTS=-Wl,-prune_interval_lto,10
+# Cross-platform linker flag
+common --repo_env=BAZEL_LINKOPTS=-Wl,-v
 
 # Verify parse_headers works as the toolchain changes
 build --process_headers_in_dependencies

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,27 @@ bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 # TODO: Remove when transitives bump past this
 bazel_dep(name = "protobuf", version = "33.0", dev_dependency = True)
 
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "swift_linux_toolchain",
+    build_file = "//test/linux_toolchain:swift_toolchain.BUILD",
+    dev_dependency = True,
+    integrity = "sha256-LDrXrXSrcknULxcu47QLyKcpiTAQtKM4S6JvPGHjUAg=",
+    strip_prefix = "swift-6.3.3-RELEASE-ubuntu22.04",
+    urls = ["https://download.swift.org/swift-6.3.3-release/ubuntu2204/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-ubuntu22.04.tar.gz"],
+)
+
+http_archive(
+    name = "swift_linux_sysroot",
+    build_file = "//test/linux_toolchain:linux_sysroot.BUILD",
+    dev_dependency = True,
+    integrity = "sha256-h8Pq+QjmfA4TqENnEZ4SJzzsHSzT2B99dLs2ci1rYHs=",
+    patch_cmds = ["mv BUILD.bazel x86_64/BUILD.bazel"],
+    strip_prefix = "swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle/swift-6.3.3-RELEASE_static-linux-0.1.0/swift-linux-musl/musl-1.2.5.sdk",
+    urls = ["https://download.swift.org/swift-6.3.3-release/static-sdk/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE_static-linux-0.1.0.artifactbundle.tar.gz"],
+)
+
 dmg_arc_test_deps = use_extension("//tools/http_dmg/private/tests:http_dmg_test_extensions.bzl", "http_dmg_test", dev_dependency = True)
 use_repo(
     dmg_arc_test_deps,
@@ -35,6 +56,11 @@ use_repo(
     "http_dmg_test_firefox_strip_prefix",
     "http_dmg_test_krita",
     "http_dmg_test_krita_strip_prefix",
+)
+
+register_toolchains(
+    "//test/linux_toolchain",
+    dev_dependency = True,
 )
 
 toolchain_env = use_repo_rule("//toolchain:toolchain_env.bzl", "toolchain_env")

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -345,7 +345,7 @@ def linking_test_suite(name):
         expected_argv = [
             "DSYM_HINT_DSYM_PATH",
             "LINKED_BINARY",
-            "-Wl,-prune_interval_lto,10",
+            "-Wl,-v",
         ],
         mnemonic = "CppLink",
         target_under_test = "//test/test_data:cc_test_binary",

--- a/test/linux_toolchain/BUILD
+++ b/test/linux_toolchain/BUILD
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    toolchain = "@swift_linux_toolchain//:cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+cc_test(
+    name = "smoke_test",
+    srcs = ["smoke.c"],
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/test/linux_toolchain/linux_sysroot.BUILD
+++ b/test/linux_toolchain/linux_sysroot.BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
+
+package(default_visibility = ["//visibility:public"])
+
+directory(
+    name = "root",
+    srcs = glob(["**/*"]),
+)
+
+# NOTE: Using this is better for merkle tree performance
+filegroup(
+    name = "directory",
+    srcs = ["."],
+)

--- a/test/linux_toolchain/smoke.c
+++ b/test/linux_toolchain/smoke.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+  puts("Swift Clang toolchain works");
+  return 0;
+}

--- a/test/linux_toolchain/swift_toolchain.BUILD
+++ b/test/linux_toolchain/swift_toolchain.BUILD
@@ -1,0 +1,99 @@
+load("@apple_support//toolchain:cc_toolchain.bzl", "cc_toolchain")
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:tool.bzl", "cc_tool")
+load("@rules_cc//cc/toolchains:tool_map.bzl", "cc_tool_map")
+load("@rules_cc//cc/toolchains/args:sysroot.bzl", "cc_sysroot")
+
+filegroup(
+    name = "clang_support_files",
+    srcs = [
+        "usr/bin/clang-21",
+        "usr/bin/ld.lld",
+        "usr/bin/x86_64-swift-linux-musl-clang.cfg",
+        "usr/bin/x86_64-swift-linux-musl-clang++.cfg",
+    ] + glob(["usr/lib/clang/21/**"]),
+)
+
+cc_tool(
+    name = "clang",
+    src = "usr/bin/clang",
+    data = [":clang_support_files"],
+)
+
+cc_tool(
+    name = "clang++",
+    src = "usr/bin/clang++",
+    data = [":clang_support_files"],
+)
+
+cc_tool(
+    name = "llvm_ar",
+    src = "usr/bin/llvm-ar",
+)
+
+cc_tool(
+    name = "llvm_cov",
+    src = "usr/bin/llvm-cov",
+)
+
+cc_tool(
+    name = "llvm_objcopy",
+    src = "usr/bin/llvm-objcopy",
+)
+
+cc_tool(
+    name = "llvm_profdata",
+    src = "usr/bin/llvm-profdata",
+)
+
+cc_tool_map(
+    name = "tools",
+    tools = {
+        "@rules_cc//cc/toolchains/actions:ar_actions": ":llvm_ar",
+        "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
+        "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":clang++",
+        "@rules_cc//cc/toolchains/actions:link_actions": ":clang++",
+        "@rules_cc//cc/toolchains/actions:llvm_cov": ":llvm_cov",
+        "@rules_cc//cc/toolchains/actions:llvm_profdata": ":llvm_profdata",
+        "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":llvm_objcopy",
+        "@rules_cc//cc/toolchains/actions:strip": ":llvm_objcopy",
+    },
+)
+
+cc_sysroot(
+    name = "sysroot_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    allowlist_include_directories = ["@swift_linux_sysroot//x86_64:root"],
+    args = ["--target=x86_64-swift-linux-musl"],
+    data = ["@swift_linux_sysroot//x86_64:directory"],
+    sysroot = "@swift_linux_sysroot//x86_64:root",
+)
+
+cc_args(
+    name = "link_toolchain_args",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = ["-rtlib=compiler-rt"],
+)
+
+cc_feature(
+    name = "sysroot_feature",
+    args = [
+        ":sysroot_args",
+        ":link_toolchain_args",
+    ],
+    feature_name = "sysroot",
+)
+
+cc_toolchain(
+    name = "cc_toolchain",
+    module_map = None,
+    supports_header_parsing = False,
+    sysroot_feature = ":sysroot_feature",
+    target = "x86_64-swift-linux-musl",
+    tool_map = ":tools",
+)

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -3618,7 +3618,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4179,6 +4178,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4183,6 +4182,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -3622,7 +3622,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4183,6 +4182,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -3622,7 +3622,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4181,6 +4180,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -3620,7 +3620,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4181,6 +4180,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -3620,7 +3620,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -3620,7 +3620,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4208,6 +4207,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -3620,7 +3620,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/linux_x86_64.json
+++ b/test/test_data/toolchain_configs/linux_x86_64.json
@@ -3557,7 +3557,36 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [],
+      "flag_sets": [
+        {
+          "actions": [
+            "c++-link-dynamic-library",
+            "c++-link-executable",
+            "c++-link-nodeps-dynamic-library",
+            "lto-index-for-dynamic-library",
+            "lto-index-for-executable",
+            "lto-index-for-nodeps-dynamic-library",
+            "objc-executable"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Wl,-v"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        }
+      ],
       "implies": [],
       "name": "__linkopts_from_env",
       "provides": [],

--- a/test/test_data/toolchain_configs/linux_x86_64.json
+++ b/test/test_data/toolchain_configs/linux_x86_64.json
@@ -7,15 +7,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang"
           },
           "type_name": "tool",
           "with_features": []
@@ -30,15 +27,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang_pp",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang_pp"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -53,15 +47,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -76,15 +67,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -99,15 +87,32 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "c++-link-nodeps-dynamic-library",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -122,15 +127,32 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/libtool",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/libtool"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-ar",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-ar"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "c++-module-codegen",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -145,15 +167,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -168,15 +187,32 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "clif-match",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -191,15 +227,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -214,15 +247,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/llvm-cov",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/llvm-cov"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-cov",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-cov"
           },
           "type_name": "tool",
           "with_features": []
@@ -237,15 +267,92 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/llvm-profdata",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/llvm-profdata"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-profdata",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-profdata"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "lto-backend",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "lto-index-for-dynamic-library",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "lto-index-for-executable",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "lto-index-for-nodeps-dynamic-library",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -260,38 +367,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang_pp",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang_pp"
-          },
-          "type_name": "tool",
-          "with_features": []
-        }
-      ],
-      "type_name": "action_config"
-    },
-    {
-      "action_name": "objc-compile",
-      "enabled": true,
-      "flag_sets": [],
-      "implies": [],
-      "tools": [
-        {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
-          "path": null,
-          "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -306,15 +387,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang++",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang++"
           },
           "type_name": "tool",
           "with_features": []
@@ -329,15 +407,32 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/libtool",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/libtool"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-ar",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-ar"
+          },
+          "type_name": "tool",
+          "with_features": []
+        }
+      ],
+      "type_name": "action_config"
+    },
+    {
+      "action_name": "objcopy_embed_data",
+      "enabled": true,
+      "flag_sets": [],
+      "implies": [],
+      "tools": [
+        {
+          "execution_requirements": [],
+          "path": null,
+          "tool": {
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-objcopy",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-objcopy"
           },
           "type_name": "tool",
           "with_features": []
@@ -352,15 +447,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/wrapped_clang",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/wrapped_clang"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/clang",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/clang"
           },
           "type_name": "tool",
           "with_features": []
@@ -375,15 +467,12 @@
       "implies": [],
       "tools": [
         {
-          "execution_requirements": [
-            "requires-darwin",
-            "supports-xcode-requirements-set"
-          ],
+          "execution_requirements": [],
           "path": null,
           "tool": {
-            "path": "bazel-out/darwin_arm64-opt-exec/bin/crosstool/strip",
-            "root": "bazel-out/darwin_arm64-opt-exec/bin",
-            "short_path": "crosstool/strip"
+            "path": "external/+http_archive+swift_linux_toolchain/usr/bin/llvm-objcopy",
+            "root": "",
+            "short_path": "../+http_archive+swift_linux_toolchain/usr/bin/llvm-objcopy"
           },
           "type_name": "tool",
           "with_features": []
@@ -392,14 +481,7 @@
       "type_name": "action_config"
     }
   ],
-  "_artifact_name_patterns_DO_NOT_USE": [
-    {
-      "category_name": "dynamic_library",
-      "extension": ".dylib",
-      "prefix": "lib",
-      "type_name": "artifact_name_pattern"
-    }
-  ],
+  "_artifact_name_patterns_DO_NOT_USE": [],
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -437,6 +519,16 @@
       "flag_sets": [],
       "implies": [],
       "name": "gcc_quoting_for_param_files",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "supports_pic",
       "provides": [],
       "requires": [],
       "type_name": "feature"
@@ -493,6 +585,28 @@
                 "%{stripopts}"
               ],
               "iterate_over": "stripopts",
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        },
+        {
+          "actions": [
+            "strip"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-p"
+              ],
+              "iterate_over": null,
               "type_name": "flag_group"
             }
           ],
@@ -697,7 +811,7 @@
                 "-no_warning_for_no_symbols",
                 "-static",
                 "-arch_only",
-                "arm64"
+                "x86_64"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -918,53 +1032,6 @@
       ],
       "implies": [],
       "name": "__header_parsing_flags",
-      "provides": [],
-      "requires": [],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-lc++"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        }
-      ],
-      "implies": [],
-      "name": "link_libc++",
       "provides": [],
       "requires": [],
       "type_name": "feature"
@@ -1518,45 +1585,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Wl,-oso_prefix,__BAZEL_EXECUTION_ROOT__/"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
-      "implies": [],
-      "name": "oso_prefix_is_pwd",
-      "provides": [],
-      "requires": [],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "strip_debug_symbols",
               "expand_if_equal": null,
               "expand_if_false": null,
@@ -1564,7 +1592,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "STRIP_DEBUG_SYMBOLS"
+                "-Wl,-S"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -1619,33 +1647,7 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-nostdlib",
-                "-Xlinker",
-                "-kext",
-                "-lcc_kext"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
+      "flag_sets": [],
       "implies": [],
       "name": "__kernel_extension_wrapper",
       "provides": [],
@@ -1683,8 +1685,7 @@
               "flag_groups": [],
               "flags": [
                 "-o",
-                "%{output_execpath}",
-                "LINKED_BINARY=%{output_execpath}"
+                "%{output_execpath}"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -1756,7 +1757,7 @@
                         "-Xlinker",
                         "-rpath",
                         "-Xlinker",
-                        "@loader_path/%{runtime_library_search_directories}"
+                        "$ORIGIN/%{runtime_library_search_directories}"
                       ],
                       "iterate_over": null,
                       "type_name": "flag_group"
@@ -1812,7 +1813,7 @@
                     "-Xlinker",
                     "-rpath",
                     "-Xlinker",
-                    "@loader_path/%{runtime_library_search_directories}"
+                    "$ORIGIN/%{runtime_library_search_directories}"
                   ],
                   "iterate_over": "runtime_library_search_directories",
                   "type_name": "flag_group"
@@ -1967,6 +1968,35 @@
                           "flag_groups": [
                             {
                               "expand_if_available": null,
+                              "expand_if_equal": null,
+                              "expand_if_false": null,
+                              "expand_if_not_available": null,
+                              "expand_if_true": "libraries_to_link.is_whole_archive",
+                              "flag_groups": [
+                                {
+                                  "expand_if_available": null,
+                                  "expand_if_equal": {
+                                    "name": "libraries_to_link.type",
+                                    "type_name": "variable_with_value",
+                                    "value": "static_library"
+                                  },
+                                  "expand_if_false": null,
+                                  "expand_if_not_available": null,
+                                  "expand_if_true": null,
+                                  "flag_groups": [],
+                                  "flags": [
+                                    "-Wl,-whole-archive"
+                                  ],
+                                  "iterate_over": null,
+                                  "type_name": "flag_group"
+                                }
+                              ],
+                              "flags": [],
+                              "iterate_over": null,
+                              "type_name": "flag_group"
+                            },
+                            {
+                              "expand_if_available": null,
                               "expand_if_equal": {
                                 "name": "libraries_to_link.type",
                                 "type_name": "variable_with_value",
@@ -1975,47 +2005,10 @@
                               "expand_if_false": null,
                               "expand_if_not_available": null,
                               "expand_if_true": null,
-                              "flag_groups": [
-                                {
-                                  "expand_if_available": null,
-                                  "expand_if_equal": null,
-                                  "expand_if_false": null,
-                                  "expand_if_not_available": null,
-                                  "expand_if_true": null,
-                                  "flag_groups": [
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": null,
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": "libraries_to_link.is_whole_archive",
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "-Wl,-force_load,%{libraries_to_link.object_files}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    },
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": "libraries_to_link.is_whole_archive",
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": null,
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "%{libraries_to_link.object_files}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    }
-                                  ],
-                                  "flags": [],
-                                  "iterate_over": null,
-                                  "type_name": "flag_group"
-                                }
+                              "flag_groups": [],
+                              "flags": [
+                                "%{libraries_to_link.object_files}"
                               ],
-                              "flags": [],
                               "iterate_over": "libraries_to_link.object_files",
                               "type_name": "flag_group"
                             },
@@ -2029,47 +2022,10 @@
                               "expand_if_false": null,
                               "expand_if_not_available": null,
                               "expand_if_true": null,
-                              "flag_groups": [
-                                {
-                                  "expand_if_available": null,
-                                  "expand_if_equal": null,
-                                  "expand_if_false": null,
-                                  "expand_if_not_available": null,
-                                  "expand_if_true": null,
-                                  "flag_groups": [
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": null,
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": "libraries_to_link.is_whole_archive",
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "-Wl,-force_load,%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    },
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": "libraries_to_link.is_whole_archive",
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": null,
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    }
-                                  ],
-                                  "flags": [],
-                                  "iterate_over": null,
-                                  "type_name": "flag_group"
-                                }
+                              "flag_groups": [],
+                              "flags": [
+                                "%{libraries_to_link.name}"
                               ],
-                              "flags": [],
                               "iterate_over": null,
                               "type_name": "flag_group"
                             },
@@ -2083,47 +2039,10 @@
                               "expand_if_false": null,
                               "expand_if_not_available": null,
                               "expand_if_true": null,
-                              "flag_groups": [
-                                {
-                                  "expand_if_available": null,
-                                  "expand_if_equal": null,
-                                  "expand_if_false": null,
-                                  "expand_if_not_available": null,
-                                  "expand_if_true": null,
-                                  "flag_groups": [
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": null,
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": "libraries_to_link.is_whole_archive",
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "-Wl,-force_load,%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    },
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": "libraries_to_link.is_whole_archive",
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": null,
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    }
-                                  ],
-                                  "flags": [],
-                                  "iterate_over": null,
-                                  "type_name": "flag_group"
-                                }
+                              "flag_groups": [],
+                              "flags": [
+                                "%{libraries_to_link.name}"
                               ],
-                              "flags": [],
                               "iterate_over": null,
                               "type_name": "flag_group"
                             },
@@ -2137,47 +2056,10 @@
                               "expand_if_false": null,
                               "expand_if_not_available": null,
                               "expand_if_true": null,
-                              "flag_groups": [
-                                {
-                                  "expand_if_available": null,
-                                  "expand_if_equal": null,
-                                  "expand_if_false": null,
-                                  "expand_if_not_available": null,
-                                  "expand_if_true": null,
-                                  "flag_groups": [
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": null,
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": "libraries_to_link.is_whole_archive",
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "-Wl,-force_load,%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    },
-                                    {
-                                      "expand_if_available": null,
-                                      "expand_if_equal": null,
-                                      "expand_if_false": "libraries_to_link.is_whole_archive",
-                                      "expand_if_not_available": null,
-                                      "expand_if_true": null,
-                                      "flag_groups": [],
-                                      "flags": [
-                                        "%{libraries_to_link.name}"
-                                      ],
-                                      "iterate_over": null,
-                                      "type_name": "flag_group"
-                                    }
-                                  ],
-                                  "flags": [],
-                                  "iterate_over": null,
-                                  "type_name": "flag_group"
-                                }
+                              "flag_groups": [],
+                              "flags": [
+                                "%{libraries_to_link.name}"
                               ],
-                              "flags": [],
                               "iterate_over": null,
                               "type_name": "flag_group"
                             },
@@ -2210,8 +2092,37 @@
                               "expand_if_true": null,
                               "flag_groups": [],
                               "flags": [
-                                "%{libraries_to_link.path}"
+                                "-l:%{libraries_to_link.name}"
                               ],
+                              "iterate_over": null,
+                              "type_name": "flag_group"
+                            },
+                            {
+                              "expand_if_available": null,
+                              "expand_if_equal": null,
+                              "expand_if_false": null,
+                              "expand_if_not_available": null,
+                              "expand_if_true": "libraries_to_link.is_whole_archive",
+                              "flag_groups": [
+                                {
+                                  "expand_if_available": null,
+                                  "expand_if_equal": {
+                                    "name": "libraries_to_link.type",
+                                    "type_name": "variable_with_value",
+                                    "value": "static_library"
+                                  },
+                                  "expand_if_false": null,
+                                  "expand_if_not_available": null,
+                                  "expand_if_true": null,
+                                  "flag_groups": [],
+                                  "flags": [
+                                    "-Wl,-no-whole-archive"
+                                  ],
+                                  "iterate_over": null,
+                                  "type_name": "flag_group"
+                                }
+                              ],
+                              "flags": [],
                               "iterate_over": null,
                               "type_name": "flag_group"
                             }
@@ -2406,7 +2317,8 @@
       "flag_sets": [
         {
           "actions": [
-            "c++-link-static-library"
+            "c++-link-static-library",
+            "objc-fully-link"
           ],
           "flag_groups": [
             {
@@ -2417,9 +2329,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-D",
-                "-no_warning_for_no_symbols",
-                "-static"
+                "rcsD"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -2441,8 +2351,29 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-o",
                 "%{output_execpath}"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        },
+        {
+          "actions": [
+            "objc-fully-link"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "fully_linked_archive_path",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "%{fully_linked_archive_path}"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -2512,6 +2443,72 @@
               ],
               "flags": [],
               "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        },
+        {
+          "actions": [
+            "objc-fully-link"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "objc_library_exec_paths",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "%{objc_library_exec_paths}"
+              ],
+              "iterate_over": "objc_library_exec_paths",
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        },
+        {
+          "actions": [
+            "objc-fully-link"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "cc_library_exec_paths",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "%{cc_library_exec_paths}"
+              ],
+              "iterate_over": "cc_library_exec_paths",
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": []
+        },
+        {
+          "actions": [
+            "objc-fully-link"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": "imported_library_exec_paths",
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "%{imported_library_exec_paths}"
+              ],
+              "iterate_over": "imported_library_exec_paths",
               "type_name": "flag_group"
             }
           ],
@@ -2827,7 +2824,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-pie"
+                "-pie"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -3058,48 +3055,6 @@
           "type_name": "feature_set"
         }
       ],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": "output_execpath",
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-object_path_lto",
-                "-Xlinker",
-                "%{output_execpath}.lto.o"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
-      "implies": [],
-      "name": "lto_object_path",
-      "provides": [],
-      "requires": [],
       "type_name": "feature"
     },
     {
@@ -3377,7 +3332,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-DOS_IOS",
                 "-fno-autolink"
               ],
               "iterate_over": null,
@@ -3403,12 +3357,18 @@
             "assemble",
             "c++-compile",
             "c++-header-parsing",
+            "c++-link-dynamic-library",
+            "c++-link-executable",
+            "c++-link-nodeps-dynamic-library",
             "c++-module-codegen",
             "c++-module-compile",
             "c-compile",
             "clif-match",
             "linkstamp-compile",
             "lto-backend",
+            "lto-index-for-dynamic-library",
+            "lto-index-for-executable",
+            "lto-index-for-nodeps-dynamic-library",
             "objc++-compile",
             "objc-compile",
             "objc-executable",
@@ -3423,10 +3383,8 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-isysroot",
-                "__BAZEL_XCODE_SDKROOT__",
-                "-F__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks",
-                "-F__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks"
+                "--sysroot=%{path:external/+http_archive+swift_linux_sysroot/x86_64}",
+                "--target=x86_64-swift-linux-musl"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -3434,18 +3392,7 @@
           ],
           "type_name": "flag_set",
           "with_features": []
-        }
-      ],
-      "implies": [],
-      "name": "sysroot",
-      "provides": [],
-      "requires": [],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
+        },
         {
           "actions": [
             "c++-link-dynamic-library",
@@ -3465,7 +3412,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-headerpad_max_install_names"
+                "-rtlib=compiler-rt"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -3475,6 +3422,16 @@
           "with_features": []
         }
       ],
+      "implies": [],
+      "name": "sysroot",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
       "implies": [],
       "name": "headerpad",
       "provides": [],
@@ -3600,36 +3557,7 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Wl,-prune_interval_lto,10"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
+      "flag_sets": [],
       "implies": [],
       "name": "__linkopts_from_env",
       "provides": [],
@@ -3671,9 +3599,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-no-canonical-prefixes",
-                "-target",
-                "arm64-apple-iosVERSION-simulator"
+                "-no-canonical-prefixes"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -3692,34 +3618,7 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "objc++-compile",
-            "objc-compile"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-fexceptions",
-                "-fasm-blocks",
-                "-fobjc-abi-version=2",
-                "-fobjc-legacy-dispatch"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
+      "flag_sets": [],
       "implies": [],
       "name": "__apply_simulator_compiler_flags",
       "provides": [],
@@ -4139,7 +4038,9 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-fobjc-link-runtime"
+                "-fuse-ld=lld",
+                "-Wl,-no-as-needed",
+                "-Wl,-z,relro,-z,now"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -4166,16 +4067,38 @@
     {
       "enabled": true,
       "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
       "flag_sets": [
         {
           "actions": [
+            "assemble",
+            "c++-compile",
+            "c++-header-parsing",
             "c++-link-dynamic-library",
             "c++-link-executable",
             "c++-link-nodeps-dynamic-library",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "c-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
             "lto-index-for-dynamic-library",
             "lto-index-for-executable",
             "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
+            "objc++-compile",
+            "objc-compile",
+            "objc-executable",
+            "preprocess-assemble"
           ],
           "flag_groups": [
             {
@@ -4186,35 +4109,17 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Xlinker",
-                "-no_deduplicate"
+                "-fdata-sections",
+                "-ffunction-sections"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
             }
           ],
           "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "opt"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
+          "with_features": []
         }
       ],
-      "implies": [],
-      "name": "no_deduplicate",
-      "provides": [],
-      "requires": [],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [],
       "implies": [],
       "name": "function_sections",
       "provides": [],
@@ -4244,7 +4149,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-dead_strip"
+                "-Wl,--gc-sections"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -4270,47 +4175,7 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        }
-      ],
+      "flag_sets": [],
       "implies": [],
       "name": "apply_implicit_frameworks",
       "provides": [],
@@ -4646,33 +4511,7 @@
     {
       "enabled": true,
       "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-nodeps-dynamic-library"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": "runtime_solib_name",
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Wl,-install_name,@rpath/%{runtime_solib_name}"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
+      "flag_sets": [],
       "implies": [],
       "name": "_soname_flags",
       "provides": [],
@@ -4770,7 +4609,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-fatal_warnings"
+                "-Wl,--fatal-warnings"
               ],
               "iterate_over": null,
               "type_name": "flag_group"
@@ -4791,84 +4630,6 @@
           "type_name": "feature_set"
         }
       ],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Wl,-no_warn_duplicate_libraries"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
-      "implies": [],
-      "name": "no_warn_duplicate_libraries",
-      "provides": [],
-      "requires": [],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [],
-      "flag_sets": [
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Wl,-reproducible"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": []
-        }
-      ],
-      "implies": [],
-      "name": "reproducible_linker_flag",
-      "provides": [],
-      "requires": [],
       "type_name": "feature"
     },
     {
@@ -4933,51 +4694,6 @@
           "type_name": "feature_set"
         }
       ],
-      "type_name": "feature"
-    },
-    {
-      "enabled": true,
-      "env_sets": [
-        {
-          "actions": [
-            "assemble",
-            "c++-compile",
-            "c++-header-parsing",
-            "c++-module-codegen",
-            "c++-module-compile",
-            "c-compile",
-            "clif-match",
-            "linkstamp-compile",
-            "lto-backend",
-            "objc++-compile",
-            "objc-compile",
-            "preprocess-assemble"
-          ],
-          "env_entries": [
-            {
-              "expand_if_available": null,
-              "key": "APPLE_SUPPORT_MODULEMAP",
-              "type_name": "env_entry",
-              "value": "APPLE_SUPPORT_MODULEMAP_PLACEHOLDER"
-            }
-          ],
-          "type_name": "env_set",
-          "with_features": [
-            {
-              "features": [
-                "layering_check"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
-        }
-      ],
-      "flag_sets": [],
-      "implies": [],
-      "name": "__layering_check_modulemap",
-      "provides": [],
-      "requires": [],
       "type_name": "feature"
     },
     {
@@ -5379,7 +5095,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Xclang",
                 "-fmodule-map-file=%{module_map_file}"
               ],
               "iterate_over": null,
@@ -5413,7 +5128,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Xclang",
                 "-fmodule-name=%{module_name}"
               ],
               "iterate_over": null,
@@ -5460,7 +5174,6 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Xclang",
                 "-fmodule-map-file=%{dependent_module_map_files}"
               ],
               "iterate_over": "dependent_module_map_files",
@@ -5486,76 +5199,7 @@
     },
     {
       "enabled": true,
-      "env_sets": [
-        {
-          "actions": [
-            "assemble",
-            "c++-compile",
-            "c++-header-analysis",
-            "c++-header-parsing",
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "c++-link-static-library",
-            "c++-module-codegen",
-            "c++-module-compile",
-            "c++-module-deps-scanning",
-            "c++20-module-codegen",
-            "c++20-module-compile",
-            "c-compile",
-            "cc-flags-make-variable",
-            "clif-match",
-            "gcov",
-            "generate-def-file",
-            "ld_embed_data",
-            "linkstamp-compile",
-            "llvm-cov",
-            "llvm-profdata",
-            "lto-backend",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "lto-indexing",
-            "objc++-compile",
-            "objc++-executable",
-            "objc-compile",
-            "objc-executable",
-            "objc-fully-link",
-            "objcopy_embed_data",
-            "preprocess-assemble",
-            "strip",
-            "validate-static-library"
-          ],
-          "env_entries": [
-            {
-              "expand_if_available": null,
-              "key": "APPLE_SDK_PLATFORM",
-              "type_name": "env_entry",
-              "value": "iPhoneSimulator"
-            },
-            {
-              "expand_if_available": null,
-              "key": "APPLE_SDK_VERSION_OVERRIDE",
-              "type_name": "env_entry",
-              "value": "APPLE_SDK_VERSION_OVERRIDE_PLACEHOLDER"
-            },
-            {
-              "expand_if_available": null,
-              "key": "XCODE_VERSION_OVERRIDE",
-              "type_name": "env_entry",
-              "value": "XCODE_VERSION_OVERRIDE_PLACEHOLDER"
-            },
-            {
-              "expand_if_available": null,
-              "key": "ZERO_AR_DATE",
-              "type_name": "env_entry",
-              "value": "1"
-            }
-          ],
-          "type_name": "env_set",
-          "with_features": []
-        }
-      ],
+      "env_sets": [],
       "flag_sets": [],
       "implies": [],
       "name": "implied_by_always_enabled_env_sets",
@@ -5569,21 +5213,16 @@
   "builtin_sysroot": "",
   "compiler": "clang",
   "cxx_builtin_include_directories": [
+    "%workspace%/external/+http_archive+swift_linux_sysroot/x86_64",
     "/Applications/",
     "/Library/",
     "/USER_HOME/Applications/",
     "/USER_HOME/Library/Developer/"
   ],
-  "make_variables": [
-    {
-      "name": "STACK_FRAME_UNLIMITED",
-      "type_name": "make_variable",
-      "value": "-Wframe-larger-than=100000000 -Wno-vla"
-    }
-  ],
-  "target_cpu": "",
-  "target_libc": "macosx",
-  "target_system_name": "arm64-apple-iosVERSION-simulator",
+  "make_variables": [],
+  "target_cpu": "k8",
+  "target_libc": "",
+  "target_system_name": "x86_64-swift-linux-musl",
   "tool_paths": [
     {
       "name": "gcov",
@@ -5591,5 +5230,5 @@
       "type_name": "tool_path"
     }
   ],
-  "toolchain_id": "@@//toolchain:toolchain"
+  "toolchain_id": "@@+http_archive+swift_linux_toolchain//:cc_toolchain"
 }

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4155,6 +4154,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4182,6 +4181,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4182,6 +4181,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4154,6 +4153,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -3593,7 +3593,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4181,6 +4180,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -3593,7 +3593,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4182,6 +4181,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4155,6 +4154,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_armv7k.json
+++ b/test/test_data/toolchain_configs/watchos_armv7k.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,

--- a/test/test_data/toolchain_configs/watchos_armv7k.json
+++ b/test/test_data/toolchain_configs/watchos_armv7k.json
@@ -3524,7 +3524,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4155,6 +4154,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4155,6 +4154,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -3594,7 +3594,7 @@
               "expand_if_true": null,
               "flag_groups": [],
               "flags": [
-                "-Wl,-prune_interval_lto,10"
+                "-Wl,-v"
               ],
               "iterate_over": null,
               "type_name": "flag_group"

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -400,7 +400,6 @@
       "type_name": "artifact_name_pattern"
     }
   ],
-  "_exec_os_DO_NOT_USE": "DARWIN",
   "_features_DO_NOT_USE": [
     {
       "enabled": true,
@@ -4182,6 +4181,16 @@
       ],
       "implies": [],
       "name": "no_deduplicate",
+      "provides": [],
+      "requires": [],
+      "type_name": "feature"
+    },
+    {
+      "enabled": true,
+      "env_sets": [],
+      "flag_sets": [],
+      "implies": [],
+      "name": "function_sections",
       "provides": [],
       "requires": [],
       "type_name": "feature"

--- a/test/toolchains_test.bzl
+++ b/test/toolchains_test.bzl
@@ -36,6 +36,9 @@ def _strip_triple_version(triple):
          arm64-apple-ios26.2-simulator -> arm64-apple-iosVERSION-simulator
     """
     parts = triple.split("-")
+    if len(parts) < 3 or parts[1] != "apple":
+        return triple
+
     os_part = parts[2]
     stripped = ""
     for c in os_part.elems():
@@ -58,6 +61,7 @@ def _sanitize_env_entries(features):
 def _config_to_json(config_info):
     # convert struct to dict
     output = json.decode(json.encode(config_info))
+    output.pop("_exec_os_DO_NOT_USE")
     output["cxx_builtin_include_directories"] = [
         _sanitize_path(x)
         for x in config_info.cxx_builtin_include_directories
@@ -234,6 +238,24 @@ def toolchain_config_test_suite(name):
             platform = platform_label,
         )
         updates.append(update_name)
+
+    linux_test_name = name + "_linux_x86_64_test"
+    _toolchain_config_test(
+        name = linux_test_name,
+        toolchain_config = "@swift_linux_toolchain//:cc_toolchain",
+        golden = "//test/test_data/toolchain_configs:linux_x86_64.json",
+        platform = "//test/linux_toolchain:linux_x86_64",
+    )
+    tests.append(linux_test_name)
+
+    linux_update_name = name + "_linux_x86_64_update"
+    _toolchain_config_update(
+        name = linux_update_name,
+        toolchain_config = "@swift_linux_toolchain//:cc_toolchain",
+        golden = "//test/test_data/toolchain_configs:linux_x86_64.json",
+        platform = "//test/linux_toolchain:linux_x86_64",
+    )
+    updates.append(linux_update_name)
 
     native.test_suite(
         name = name,

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -9,9 +9,11 @@ load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:legacy_tool.bzl", "cc_legacy_tool")
 load("@rules_cc//cc/toolchains:make_variable.bzl", "cc_make_variable")
 load("@rules_cc//cc/toolchains:nested_args.bzl", "cc_nested_args")
-load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
+load(":cc_toolchain.bzl", "cc_toolchain")
 load(":dynamic_toolchain_info.bzl", "dynamic_toolchain_info", "xcode_execution_info")
 load(":features.bzl", "enableable_feature", "negatable_feature")
+
+package(default_visibility = ["//visibility:public"])
 
 # Consumers can append an extra cc_args (for example with
 # allowlist_absolute_include_directories for hermetic Xcodes vendored into
@@ -83,6 +85,27 @@ _LIMITED_COMPILE_ACTIONS = [
     )
     for name in MARKER_FEATURES
 ]
+
+cc_feature(
+    name = "supports_pic",
+    feature_name = "supports_pic",
+)
+
+cc_feature_set(
+    name = "_marker_features",
+    all_of = MARKER_FEATURES + select({
+        "//configs:apple": [],
+        "//conditions:default": [":supports_pic"],
+    }),
+)
+
+cc_feature_set(
+    name = "_enabled_markers",
+    all_of = ENABLED_MARKERS + select({
+        "//configs:apple": [],
+        "//conditions:default": [":supports_pic"],
+    }),
+)
 
 cc_feature(
     name = "dbg",
@@ -281,7 +304,7 @@ cc_args(
 
 dynamic_toolchain_info(
     name = "dynamic_toolchain_info",
-    visibility = ["//toolchain:__subpackages__"],
+    visibility = ["//:__subpackages__"],
 )
 
 xcode_execution_info(
@@ -297,10 +320,17 @@ negatable_feature(
     ],
     args = [
         "-no-canonical-prefixes",
-        "-target",
-        "{TARGET}",
-    ],
-    toolchains = [":dynamic_toolchain_info"],
+    ] + select({
+        "//configs:apple": [
+            "-target",
+            "{TARGET}",
+        ],
+        "//conditions:default": [],
+    }),
+    toolchains = select({
+        "//configs:apple": [":dynamic_toolchain_info"],
+        "//conditions:default": [],
+    }),
 )
 
 negatable_feature(
@@ -323,7 +353,14 @@ negatable_feature(
 cc_args(
     name = "default_link_flags_base_args",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-fobjc-link-runtime"],
+    args = select({
+        "//configs:apple": ["-fobjc-link-runtime"],
+        "//conditions:default": [
+            "-fuse-ld=lld",
+            "-Wl,-no-as-needed",
+            "-Wl,-z,relro,-z,now",
+        ],
+    }),
     requires_any_of = [":not_kernel_extension"],
 )
 
@@ -383,7 +420,10 @@ cc_args(
 cc_args(
     name = "treat_warnings_as_errors_link_args",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-Wl,-fatal_warnings"],
+    args = select({
+        "//configs:apple": ["-Wl,-fatal_warnings"],
+        "//conditions:default": ["-Wl,--fatal-warnings"],
+    }),
 )
 
 enableable_feature(
@@ -452,6 +492,14 @@ negatable_feature(
 config_setting(
     name = "no_xcode_version",
     flag_values = {"@bazel_tools//tools/osx:xcode_version_flag_major": "None"},
+)
+
+alias(
+    name = "apple_env",
+    actual = select({
+        ":no_xcode_version": ":clt_env",
+        "//conditions:default": ":xcode_env",
+    }),
 )
 
 selects.config_setting_group(
@@ -526,6 +574,18 @@ negatable_feature(
     requires_not_none = "@rules_cc//cc/toolchains/variables:output_execpath",
 )
 
+negatable_feature(
+    name = "linux_output_execpath_flags",
+    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+    args = [
+        "-o",
+        "{output_execpath}",
+    ],
+    format = {"output_execpath": "@rules_cc//cc/toolchains/variables:output_execpath"},
+    overrides = "@rules_cc//cc/toolchains/features/legacy:output_execpath_flags",
+    requires_not_none = "@rules_cc//cc/toolchains/variables:output_execpath",
+)
+
 # We need to pass -object_path_lto in order to get debug symbols when building
 # with LTO. In a perfect world, we would only pass it when the thin_lto or
 # full_lto features are enabled. However, when these features are enabled,
@@ -569,10 +629,13 @@ negatable_feature(
 negatable_feature(
     name = "no_deduplicate",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = [
-        "-Xlinker",
-        "-no_deduplicate",
-    ],
+    args = select({
+        "//configs:apple": [
+            "-Xlinker",
+            "-no_deduplicate",
+        ],
+        "//conditions:default": [],
+    }),
     requires_any_of = [":not_opt_mode"],
 )
 
@@ -589,13 +652,34 @@ negatable_feature(
 negatable_feature(
     name = "headerpad",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-headerpad_max_install_names"],
+    args = select({
+        "//configs:apple": ["-headerpad_max_install_names"],
+        "//conditions:default": [],
+    }),
+)
+
+negatable_feature(
+    name = "function_sections",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = select({
+        "//configs:apple": [],
+        "//conditions:default": [
+            "-fdata-sections",
+            "-ffunction-sections",
+        ],
+    }),
 )
 
 enableable_feature(
     name = "dead_strip",
     actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-dead_strip"],
+    args = select({
+        "//configs:apple": ["-dead_strip"],
+        "//conditions:default": ["-Wl,--gc-sections"],
+    }),
 )
 
 negatable_feature(
@@ -794,132 +878,9 @@ cc_legacy_tool(
 
 cc_toolchain(
     name = "toolchain",
-    args = [
-        "@apple_support_toolchain_env//:include_directories_from_xcode",
-        ":extra_include_directories",
-    ] + select({
-        ":no_xcode_version": [":clt_env"],
-        "//conditions:default": [":xcode_env"],
-    }),
-    artifact_name_patterns = [":dylib_pattern"],
-    compiler = "clang",
-    # TODO: Use experimental_replace_legacy_action_config_features as long as ordering isn't an issue
-    enabled_features = ENABLED_MARKERS + [
-        # NOTE: ORDER MATTERS
-        "@rules_cc//cc/toolchains/args/layering_check:module_maps",  # NOTE: This is a marker feature
-        "@rules_cc//cc/toolchains/args/strip_flags:feature",
-        "//toolchain/objc:__objc_executable_feature",
-        "//toolchain/objc:__objc_fully_link_feature",
-        ":__header_parsing_flags",  # NOTE: Must come before input files
-        ":link_libc++",
-        ":default_compile_flags_feature",
-        ":ns_block_assertions",
-        ":debug_prefix_map_pwd_is_dot",
-        ":remap_xcode_path",
-        ":generate_dsym_file_wrapper",
-        ":generate_linkmap_wrapper",
-        ":oso_prefix_is_pwd",
-        ":strip_debug_symbols",
-        "@rules_cc//cc/toolchains/args/shared_flag:feature",
-        ":kernel_extension_wrapper",
-        ":output_execpath_flags",
-        "@rules_cc//cc/toolchains/args/runtime_library_search_directories:feature",
-        "@rules_cc//cc/toolchains/args/library_search_directories:feature",
-        "@rules_cc//cc/toolchains/args/libraries_to_link:feature",
-        "//toolchain/objc:objc_link_flag",
-        ":pch",
-        "//toolchain/objc:__apple_default_warnings",
-        ":__archiver_flags",
-        "@rules_cc//cc/toolchains/args/include_flags:feature",
-        "@rules_cc//cc/toolchains/args/dependency_file:feature",
-        ":serialized_diagnostics_file_wrapper",
-        "@rules_cc//cc/toolchains/args/pic_flags:feature",
-        "@rules_cc//cc/toolchains/args/preprocessor_defines:feature",
-        "//toolchain/pgo:fdo_instrument_wrapper",
-        "//toolchain/pgo:fdo_optimize_wrapper",
-        "//toolchain/pgo:autofdo_wrapper",
-        ":lto_object_path",
-        "//toolchain/coverage:llvm_coverage_map_format_wrapper",
-        "//toolchain/coverage:gcc_coverage_map_format_wrapper",
-        "//toolchain/coverage:coverage_prefix_map",
-        "//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic_wrapper",
-        "//toolchain/objc:__apple_default_compiler_flags",
-        ":sysroot_feature",
-        ":headerpad",
-        "@rules_cc//cc/toolchains/args/objc_arc_flags:feature",
-        ":user_link_flags",  # TODO: Switch to upstream feature
-        "@apple_support_toolchain_env//:linkopts_from_env",  # TODO: Join with the copts below
-        ":default_required_flags",
-        ":__apply_simulator_compiler_flags",
-        "//toolchain/sanitizers:asan_wrapper",
-        "//toolchain/sanitizers:tsan_wrapper",
-        "//toolchain/sanitizers:ubsan_wrapper",
-        "//toolchain/sanitizers:default_sanitizer_flags",
-        "@apple_support_toolchain_env//:copts_from_env",
-        ":default_link_flags",
-    ] + select({
-        ":opt_mode": [":dead_strip"],
-        "//conditions:default": [],
-    }) + [
-        ":no_deduplicate",
-        ":dead_strip_wrapper",
-        ":apply_implicit_frameworks",
-        ":link_cocoa_wrapper",
-        ":extra_enabled_features",
-        "@rules_cc//cc/toolchains/args/compile_flags:user_compile_flags_feature",  # TODO: Switch to compile_flags:feature if ordering isn't an issue
-        ":unfiltered_compile_flags",
-        "@rules_cc//cc/toolchains/args/compiler_input_flags:feature",
-        "@rules_cc//cc/toolchains/args/compiler_output_flags:feature",
-        "@rules_cc//cc/toolchains/args/linker_param_file:feature",
-        "@rules_cc//cc/toolchains/args/soname_flags:feature",
-        ":suppress_warnings_wrapper",
-        ":treat_warnings_as_errors_wrapper",
-        ":no_warn_duplicate_libraries",
-        ":reproducible_linker_flag",
-        ":external_include_paths_wrapper",
-        "@apple_support_toolchain_env//:off_by_default_layering_check_enabled_features",
-    ],
-    known_features = MARKER_FEATURES + [
-        ":opt",
-        ":dbg",
-        ":fastbuild",
-        "//toolchain/coverage",
-        ":kernel_extension",
-        ":serialized_diagnostics_file",
-        "//toolchain/coverage:llvm_coverage_map_format",
-        "//toolchain/coverage:gcc_coverage_map_format",
-        "//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic",
-        "//toolchain/sanitizers:asan",
-        "//toolchain/sanitizers:tsan",
-        "//toolchain/sanitizers:ubsan",
-        ":generate_dsym_file",
-        ":generate_linkmap",
-        ":link_cocoa",
-        ":dead_strip",
-        ":suppress_warnings",
-        ":treat_warnings_as_errors",
-        ":external_include_paths",
-        "//toolchain/pgo:fdo_instrument",
-        "//toolchain/pgo:autofdo",
-        "//toolchain/pgo:fdo_optimize",
-        "@apple_support_toolchain_env//:off_by_default_layering_check_known_features",
-        ":extra_known_features",
-        "@rules_cc//cc/toolchains/args/layering_check:use_module_maps",  # TODO: https://github.com/bazelbuild/rules_cc/pull/657
-    ] + select({
-        "@platforms//os:macos": [
-            ":dynamic_linking_mode",
-        ],
-        "//conditions:default": [],
-    }),
-    legacy_tools = [
-        ":gcov",
-    ],
-    make_variables = [":stack_frame_variable"],
     module_map = "//crosstool:module.modulemap",
     supports_header_parsing = True,
-    supports_param_files = True,
-    target_system_name = "$(TARGET)",
+    sysroot_feature = ":sysroot_feature",
+    target = "$(TARGET)",
     tool_map = "//toolchain/tools",
-    toolchains = [":dynamic_toolchain_info"],
-    visibility = ["//:__subpackages__"],
 )

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -1,0 +1,197 @@
+"""Create a clang toolchain that optionally supports Apple platforms."""
+
+load("@rules_cc//cc/toolchains:toolchain.bzl", _cc_toolchain = "cc_toolchain")
+
+# NOTE: Ideally this would be limited but there is a huge variety of repo names
+# used by rules_swift for this
+visibility("public")
+
+def cc_toolchain(
+        *,
+        name,
+        target,
+        module_map,
+        sysroot_feature,
+        supports_header_parsing,
+        tool_map):
+    """Defines a C/C++ toolchain with Apple defaults on Apple platforms.
+
+    Args:
+        name: The name of the toolchain target.
+        target: The target triple for the toolchain.
+        module_map: Module map artifact for modular builds.
+        supports_header_parsing: Whether header parsing actions are supported.
+        sysroot_feature: The enabled feature that supplies the toolchain's sysroot.
+        tool_map: The `cc_tool_map` that supplies the toolchain's tools.
+    """
+    _cc_toolchain(
+        name = name,
+        args = [
+            Label("@apple_support_toolchain_env//:include_directories_from_xcode"),
+            Label("//toolchain:extra_include_directories"),
+        ] + select({
+            Label("//configs:apple"): [Label("//toolchain:apple_env")],
+            "//conditions:default": [],
+        }),
+        artifact_name_patterns = select({
+            Label("//configs:apple"): [Label("//toolchain:dylib_pattern")],
+            "//conditions:default": [],
+        }),
+        compiler = "clang",
+        # TODO: Use experimental_replace_legacy_action_config_features as long as ordering isn't an issue
+        enabled_features = [
+            # NOTE: ORDER MATTERS
+            Label("//toolchain:_enabled_markers"),
+            Label("@rules_cc//cc/toolchains/args/layering_check:module_maps"),  # NOTE: This is a marker feature
+            Label("@rules_cc//cc/toolchains/args/strip_flags:feature"),
+            Label("//toolchain/objc:__objc_executable_feature"),
+            Label("//toolchain/objc:__objc_fully_link_feature"),
+            Label("//toolchain:__header_parsing_flags"),  # NOTE: Must come before input files
+        ] + select({
+            Label("//configs:apple"): [
+                Label("//toolchain:link_libc++"),
+            ],
+            "//conditions:default": [],
+        }) + [
+            Label("//toolchain:default_compile_flags_feature"),
+            Label("//toolchain:ns_block_assertions"),
+            Label("//toolchain:debug_prefix_map_pwd_is_dot"),
+            Label("//toolchain:remap_xcode_path"),
+            Label("//toolchain:generate_dsym_file_wrapper"),
+            Label("//toolchain:generate_linkmap_wrapper"),
+        ] + select({
+            Label("//configs:apple"): [Label("//toolchain:oso_prefix_is_pwd")],
+            "//conditions:default": [],
+        }) + select({
+            Label("//configs:apple"): [Label("//toolchain:strip_debug_symbols")],
+            "//conditions:default": [Label("@rules_cc//cc/toolchains/args/strip_debug_symbols:feature")],
+        }) + [
+            Label("@rules_cc//cc/toolchains/args/shared_flag:feature"),
+            Label("//toolchain:kernel_extension_wrapper"),
+        ] + select({
+            Label("//configs:apple"): [Label("//toolchain:output_execpath_flags")],
+            "//conditions:default": [Label("//toolchain:linux_output_execpath_flags")],
+        }) + [
+            Label("@rules_cc//cc/toolchains/args/runtime_library_search_directories:feature"),
+            Label("@rules_cc//cc/toolchains/args/library_search_directories:feature"),
+            Label("@rules_cc//cc/toolchains/args/libraries_to_link:feature"),
+            Label("//toolchain/objc:objc_link_flag"),
+            Label("//toolchain:pch"),
+            Label("//toolchain/objc:__apple_default_warnings"),
+        ] + select({
+            Label("//configs:apple"): [Label("//toolchain:__archiver_flags")],
+            "//conditions:default": [Label("@rules_cc//cc/toolchains/args/archiver_flags:feature")],
+        }) + [
+            Label("@rules_cc//cc/toolchains/args/include_flags:feature"),
+            Label("@rules_cc//cc/toolchains/args/dependency_file:feature"),
+            Label("//toolchain:serialized_diagnostics_file_wrapper"),
+            Label("@rules_cc//cc/toolchains/args/pic_flags:feature"),
+            Label("@rules_cc//cc/toolchains/args/preprocessor_defines:feature"),
+            Label("//toolchain/pgo:fdo_instrument_wrapper"),
+            Label("//toolchain/pgo:fdo_optimize_wrapper"),
+            Label("//toolchain/pgo:autofdo_wrapper"),
+        ] + select({
+            Label("//configs:apple"): [Label("//toolchain:lto_object_path")],
+            "//conditions:default": [],
+        }) + [
+            Label("//toolchain/coverage:llvm_coverage_map_format_wrapper"),
+            Label("//toolchain/coverage:gcc_coverage_map_format_wrapper"),
+            Label("//toolchain/coverage:coverage_prefix_map"),
+            Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic_wrapper"),
+            Label("//toolchain/objc:__apple_default_compiler_flags"),
+        ] + [sysroot_feature] + [
+            Label("//toolchain:headerpad"),
+            Label("@rules_cc//cc/toolchains/args/objc_arc_flags:feature"),
+            Label("//toolchain:user_link_flags"),  # TODO: Switch to upstream feature
+            Label("@apple_support_toolchain_env//:linkopts_from_env"),  # TODO: Join with the copts below
+            Label("//toolchain:default_required_flags"),
+            Label("//toolchain:__apply_simulator_compiler_flags"),
+            Label("//toolchain/sanitizers:asan_wrapper"),
+            Label("//toolchain/sanitizers:tsan_wrapper"),
+            Label("//toolchain/sanitizers:ubsan_wrapper"),
+            Label("//toolchain/sanitizers:default_sanitizer_flags"),
+            Label("@apple_support_toolchain_env//:copts_from_env"),
+            Label("//toolchain:default_link_flags"),
+        ] + select({
+            Label("//toolchain:opt_mode"): [Label("//toolchain:dead_strip")],
+            "//conditions:default": [],
+        }) + [
+            Label("//toolchain:no_deduplicate"),
+            Label("//toolchain:function_sections"),
+            Label("//toolchain:dead_strip_wrapper"),
+            Label("//toolchain:apply_implicit_frameworks"),
+            Label("//toolchain:link_cocoa_wrapper"),
+            Label("//toolchain:extra_enabled_features"),
+            Label("@rules_cc//cc/toolchains/args/compile_flags:user_compile_flags_feature"),  # TODO: Switch to compile_flags:feature if ordering isn't an issue
+            Label("//toolchain:unfiltered_compile_flags"),
+            Label("@rules_cc//cc/toolchains/args/compiler_input_flags:feature"),
+            Label("@rules_cc//cc/toolchains/args/compiler_output_flags:feature"),
+            Label("@rules_cc//cc/toolchains/args/linker_param_file:feature"),
+            Label("@rules_cc//cc/toolchains/args/soname_flags:feature"),
+            Label("//toolchain:suppress_warnings_wrapper"),
+            Label("//toolchain:treat_warnings_as_errors_wrapper"),
+        ] + select({
+            Label("//configs:apple"): [
+                Label("//toolchain:no_warn_duplicate_libraries"),
+                Label("//toolchain:reproducible_linker_flag"),
+            ],
+            "//conditions:default": [],
+        }) + [
+            Label("//toolchain:external_include_paths_wrapper"),
+        ] + select({
+            Label("//configs:apple"): [
+                Label("@apple_support_toolchain_env//:off_by_default_layering_check_enabled_features"),
+            ],
+            "//conditions:default": [],
+        }),
+        known_features = [
+            Label("//toolchain:_marker_features"),
+            Label("//toolchain:opt"),
+            Label("//toolchain:dbg"),
+            Label("//toolchain:fastbuild"),
+            Label("//toolchain/coverage"),
+            Label("//toolchain:kernel_extension"),
+            Label("//toolchain:serialized_diagnostics_file"),
+            Label("//toolchain/coverage:llvm_coverage_map_format"),
+            Label("//toolchain/coverage:gcc_coverage_map_format"),
+            Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic"),
+            Label("//toolchain/sanitizers:asan"),
+            Label("//toolchain/sanitizers:tsan"),
+            Label("//toolchain/sanitizers:ubsan"),
+            Label("//toolchain:generate_dsym_file"),
+            Label("//toolchain:generate_linkmap"),
+            Label("//toolchain:link_cocoa"),
+            Label("//toolchain:dead_strip"),
+            Label("//toolchain:suppress_warnings"),
+            Label("//toolchain:treat_warnings_as_errors"),
+            Label("//toolchain:external_include_paths"),
+            Label("//toolchain/pgo:fdo_instrument"),
+            Label("//toolchain/pgo:autofdo"),
+            Label("//toolchain/pgo:fdo_optimize"),
+            Label("@apple_support_toolchain_env//:off_by_default_layering_check_known_features"),
+            Label("//toolchain:extra_known_features"),
+            Label("@rules_cc//cc/toolchains/args/layering_check:use_module_maps"),  # TODO: https://github.com/bazelbuild/rules_cc/pull/657
+        ] + select({
+            Label("@platforms//os:macos"): [
+                Label("//toolchain:dynamic_linking_mode"),
+            ],
+            "//conditions:default": [],
+        }),
+        legacy_tools = [
+            Label("//toolchain:gcov"),
+        ],
+        make_variables = select({
+            Label("//configs:apple"): [Label("//toolchain:stack_frame_variable")],
+            "//conditions:default": [],
+        }),
+        module_map = module_map,
+        supports_header_parsing = supports_header_parsing,
+        supports_param_files = True,
+        target_system_name = target,
+        tool_map = tool_map,
+        toolchains = select({
+            Label("//configs:apple"): [Label("//toolchain:dynamic_toolchain_info")],
+            "//conditions:default": [],
+        }),
+        visibility = ["//visibility:public"],
+    )

--- a/toolchain/coverage/BUILD
+++ b/toolchain/coverage/BUILD
@@ -2,7 +2,7 @@ load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("//toolchain:features.bzl", "enableable_feature", "negatable_feature")
 
-package(default_visibility = ["//toolchain:__pkg__"])
+package(default_visibility = ["//visibility:public"])
 
 _COVERAGE_COMPILE_ACTIONS = [
     # TODO: Should all compile actions be here?

--- a/toolchain/dynamic_toolchain_info.bzl
+++ b/toolchain/dynamic_toolchain_info.bzl
@@ -45,6 +45,19 @@ def _sdk_name(platform_type, is_simulator):
         fail("Unhandled platform type: {}".format(platform_type))
 
 def _dynamic_toolchain_info_impl(ctx):
+    if ctx.target_platform_has_constraint(ctx.attr._arm64[platform_common.ConstraintValueInfo]):
+        triple_arch = "arm64"
+    elif ctx.target_platform_has_constraint(ctx.attr._arm64e[platform_common.ConstraintValueInfo]):
+        triple_arch = "arm64e"
+    elif ctx.target_platform_has_constraint(ctx.attr._x86_64[platform_common.ConstraintValueInfo]):
+        triple_arch = "x86_64"
+    elif ctx.target_platform_has_constraint(ctx.attr._arm64_32[platform_common.ConstraintValueInfo]):
+        triple_arch = "arm64_32"
+    elif ctx.target_platform_has_constraint(ctx.attr._armv7k[platform_common.ConstraintValueInfo]):
+        triple_arch = "armv7k"
+    else:
+        fail("Unknown CPU in target platform")
+
     if ctx.target_platform_has_constraint(ctx.attr._macos[platform_common.ConstraintValueInfo]):
         triple_os = "macosx"
         platform_type = apple_common.platform_type.macos
@@ -60,21 +73,10 @@ def _dynamic_toolchain_info_impl(ctx):
     elif ctx.target_platform_has_constraint(ctx.attr._visionos[platform_common.ConstraintValueInfo]):
         triple_os = "xros"
         platform_type = getattr(apple_common.platform_type, "visionos", None)
+    elif ctx.target_platform_has_constraint(ctx.attr._linux[platform_common.ConstraintValueInfo]):
+        return [platform_common.TemplateVariableInfo({"ARCH": triple_arch})]
     else:
         fail("Unknown OS in target platform")
-
-    if ctx.target_platform_has_constraint(ctx.attr._arm64[platform_common.ConstraintValueInfo]):
-        triple_arch = "arm64"
-    elif ctx.target_platform_has_constraint(ctx.attr._arm64e[platform_common.ConstraintValueInfo]):
-        triple_arch = "arm64e"
-    elif ctx.target_platform_has_constraint(ctx.attr._x86_64[platform_common.ConstraintValueInfo]):
-        triple_arch = "x86_64"
-    elif ctx.target_platform_has_constraint(ctx.attr._arm64_32[platform_common.ConstraintValueInfo]):
-        triple_arch = "arm64_32"
-    elif ctx.target_platform_has_constraint(ctx.attr._armv7k[platform_common.ConstraintValueInfo]):
-        triple_arch = "armv7k"
-    else:
-        fail("Unknown CPU in target platform")
 
     is_simulator = ctx.target_platform_has_constraint(ctx.attr._simulator[platform_common.ConstraintValueInfo])
     if is_simulator:
@@ -116,6 +118,7 @@ def _dynamic_toolchain_info_impl(ctx):
 dynamic_toolchain_info = rule(
     implementation = _dynamic_toolchain_info_impl,
     attrs = {
+        "_linux": attr.label(default = "@platforms//os:linux"),
         "_macos": attr.label(default = "@platforms//os:macos"),
         "_ios": attr.label(default = "@platforms//os:ios"),
         "_tvos": attr.label(default = "@platforms//os:tvos"),

--- a/toolchain/objc/BUILD
+++ b/toolchain/objc/BUILD
@@ -1,7 +1,7 @@
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 load("//toolchain:features.bzl", "negatable_feature")
 
-package(default_visibility = ["//toolchain:__pkg__"])
+package(default_visibility = ["//visibility:public"])
 
 negatable_feature(
     name = "__apple_default_warnings",
@@ -39,7 +39,7 @@ negatable_feature(
         "@platforms//os:ios": ["-DOS_IOS"],
         "@platforms//os:watchos": ["-DOS_IOS"],  # NOTE: This is weird
         "@platforms//os:tvos": ["-DOS_TVOS"],
-        "@platforms//os:visionos": [],
+        "//conditions:default": [],
     }) + ["-fno-autolink"],
 )
 

--- a/toolchain/pgo/BUILD
+++ b/toolchain/pgo/BUILD
@@ -1,7 +1,7 @@
 load("@rules_cc//cc/toolchains:mutually_exclusive_category.bzl", "cc_mutually_exclusive_category")
 load("//toolchain:features.bzl", "enableable_feature")
 
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 cc_mutually_exclusive_category(
     name = "profile",

--- a/toolchain/sanitizers/BUILD
+++ b/toolchain/sanitizers/BUILD
@@ -3,7 +3,7 @@ load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
 load("//toolchain:features.bzl", "enableable_feature")
 
-package(default_visibility = ["//toolchain:__pkg__"])
+package(default_visibility = ["//visibility:public"])
 
 _LIMITED_COMPILE_ACTIONS = [
     "@rules_cc//cc/toolchains/actions:c_compile",

--- a/toolchain/toolchain_env.bzl
+++ b/toolchain/toolchain_env.bzl
@@ -143,7 +143,7 @@ load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
 load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
 
-package(default_visibility = ["@apple_support//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
 
 cc_feature(
     name = "copts_from_env",


### PR DESCRIPTION
With expanding Swift toolchain support in rules_swift, for many platforms, we need
a cc toolchain that potentially uses Apple's clang that ships with Swift on Linux.

This lets us re-use the majority of our Apple toolchain but for targeting embedded
or linux. This means we don't have to worry about incompatibilities from a host gcc
toolchain, or a mismatched clang version toolchain. Users wouldn't particularly
have to use this still, but it's a better default than what rules_cc gives us.
Since we're already downloading the Swift toolchain that has clang in rules_swift
there's also no downside there.