### PR TITLE
Fix dead_strip behavior

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -871,11 +871,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
                 flag_groups = [flag_group(flags = ["-fobjc-link-runtime"])],
                 with_features = [with_feature_set(not_features = ["kernel_extension"])],
             ),
-            flag_set(
-                actions = _DYNAMIC_LINK_ACTIONS,
-                flag_groups = [flag_group(flags = ["-dead_strip"])],
-                with_features = [with_feature_set(features = ["opt"])],
-            ),
         ],
     )
 
@@ -1694,6 +1689,7 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
 
     dead_strip_feature = feature(
         name = "dead_strip",
+        enabled = ctx.var["COMPILATION_MODE"] == "opt",
         flag_sets = [
             flag_set(
                 actions = _DYNAMIC_LINK_ACTIONS,

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -25,11 +25,26 @@ opt_test = make_action_command_line_test_rule(
     },
 )
 
+fastbuild_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "fastbuild",
+    },
+)
+
 dead_strip_requested_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:compilation_mode": "fastbuild",
         "//command_line_option:features": [
             "dead_strip",
+        ],
+    },
+)
+
+opt_dead_strip_disabled_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": [
+            "-dead_strip",
         ],
     },
 )
@@ -179,6 +194,14 @@ def linking_test_suite(name):
         target_under_test = "//test/test_data:macos_binary",
     )
 
+    fastbuild_test(
+        name = "{}_fastbuild_link_test".format(name),
+        tags = [name],
+        not_expected_argv = ["-dead_strip"],
+        mnemonic = "ObjcLink",
+        target_under_test = "//test/test_data:macos_binary",
+    )
+
     dead_strip_requested_test(
         name = "{}_dead_strip_requested_test".format(name),
         tags = [name],
@@ -190,6 +213,14 @@ def linking_test_suite(name):
             "-ObjC",
             "-dead_strip",
         ],
+        mnemonic = "ObjcLink",
+        target_under_test = "//test/test_data:macos_binary",
+    )
+
+    opt_dead_strip_disabled_test(
+        name = "{}_opt_dead_strip_disabled_test".format(name),
+        tags = [name],
+        not_expected_argv = ["-dead_strip"],
         mnemonic = "ObjcLink",
         target_under_test = "//test/test_data:macos_binary",
     )

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -3922,42 +3922,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -3926,42 +3926,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -3926,42 +3926,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -3924,42 +3924,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -3924,42 +3924,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -3951,42 +3951,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -3951,42 +3951,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -3898,42 +3898,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -3925,42 +3925,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -3925,42 +3925,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -3897,42 +3897,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -3924,42 +3924,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -3925,42 +3925,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -3898,42 +3898,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_armv7k.json
+++ b/test/test_data/toolchain_configs/watchos_armv7k.json
@@ -3768,42 +3768,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -3898,42 +3898,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -3898,42 +3898,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -3925,42 +3925,6 @@
               "type_name": "with_feature_set"
             }
           ]
-        },
-        {
-          "actions": [
-            "c++-link-dynamic-library",
-            "c++-link-executable",
-            "c++-link-nodeps-dynamic-library",
-            "lto-index-for-dynamic-library",
-            "lto-index-for-executable",
-            "lto-index-for-nodeps-dynamic-library",
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-dead_strip"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [
-                "opt"
-              ],
-              "not_features": [],
-              "type_name": "with_feature_set"
-            }
-          ]
         }
       ],
       "implies": [],

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -102,6 +102,11 @@ cc_feature(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "opt_mode",
+    values = {"compilation_mode": "opt"},
+)
+
 cc_feature(
     name = "dynamic_linking_mode",
     overrides = "@rules_cc//cc/toolchains/features:dynamic_linking_mode",
@@ -322,19 +327,9 @@ cc_args(
     requires_any_of = [":not_kernel_extension"],
 )
 
-cc_args(
-    name = "default_link_flags_opt_args",
-    actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
-    args = ["-dead_strip"],
-    requires_any_of = [":opt"],
-)
-
 negatable_feature(
     name = "default_link_flags",
-    custom_args = [
-        ":default_link_flags_base_args",
-        ":default_link_flags_opt_args",
-    ],
+    custom_args = [":default_link_flags_base_args"],
 )
 
 cc_args(
@@ -858,6 +853,10 @@ cc_toolchain(
         ":__apply_simulator_compiler_flags",
         "@apple_support_toolchain_env//:copts_from_env",
         ":default_link_flags",
+    ] + select({
+        ":opt_mode": [":dead_strip"],
+        "//conditions:default": [],
+    }) + [
         ":no_deduplicate",
         ":dead_strip_wrapper",
         ":apply_implicit_frameworks",


### PR DESCRIPTION
- Enabled by default for opt
- Enabled when requested with `--features=dead_strip` (implied by
  rules_cc in some cases)
- Can be disabled with `--features=-dead_strip` even for opt mode

Fixes https://github.com/bazelbuild/apple_support/issues/308
