### PR TITLE
Remove -objc_abi_version linker flag

### DIFF
--- a/crosstool/cc_toolchain_config.bzl
+++ b/crosstool/cc_toolchain_config.bzl
@@ -383,20 +383,6 @@ please file an issue at https://github.com/bazelbuild/apple_support/issues/new
             flag_set(
                 actions = [ACTION_NAMES.objc_executable],
                 flag_groups = [
-                    flag_group(
-                        flags = [
-                            "-Xlinker",
-                            "-objc_abi_version",
-                            "-Xlinker",
-                            "2",
-                        ],
-                    ),
-                ],
-                with_features = [with_feature_set(not_features = ["kernel_extension"])],
-            ),
-            flag_set(
-                actions = [ACTION_NAMES.objc_executable],
-                flag_groups = [
                     flag_group(flags = ["-filelist", "%{filelist}"]),
                     flag_group(flags = ["-o", "%{linked_binary}", "LINKED_BINARY=%{linked_binary}"]),
                     flag_group(

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -121,10 +121,6 @@ def linking_test_suite(name):
         name = "{}_default_apple_macos_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
             "LINKED_BINARY",
             "-ObjC",
             "-framework",
@@ -143,10 +139,6 @@ def linking_test_suite(name):
         name = "{}_default_apple_ios_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
             "LINKED_BINARY",
             "-ObjC",
             "-framework",
@@ -168,10 +160,6 @@ def linking_test_suite(name):
         name = "{}_opt_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
             "-ObjC",
             "-dead_strip",
         ],
@@ -183,10 +171,6 @@ def linking_test_suite(name):
         name = "{}_dead_strip_requested_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
             "-ObjC",
             "-dead_strip",
         ],
@@ -198,10 +182,7 @@ def linking_test_suite(name):
         name = "{}_disable_objc_apple_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
+            "LINKED_BINARY",
             "-framework",
             "Foundation",
         ],
@@ -214,10 +195,7 @@ def linking_test_suite(name):
         name = "{}_disable_implicit_frameworks_apple_macos_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
+            "LINKED_BINARY",
             "-ObjC",
         ],
         not_expected_argv = [
@@ -232,10 +210,7 @@ def linking_test_suite(name):
         name = "{}_disable_implicit_frameworks_apple_ios_link_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xlinker",
-            "-objc_abi_version",
-            "-Xlinker",
-            "2",
+            "LINKED_BINARY",
             "-ObjC",
         ],
         not_expected_argv = [

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_armv7k.json
+++ b/test/test_data/toolchain_configs/watchos_armv7k.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -562,39 +562,6 @@
           ],
           "flag_groups": [
             {
-              "expand_if_available": null,
-              "expand_if_equal": null,
-              "expand_if_false": null,
-              "expand_if_not_available": null,
-              "expand_if_true": null,
-              "flag_groups": [],
-              "flags": [
-                "-Xlinker",
-                "-objc_abi_version",
-                "-Xlinker",
-                "2"
-              ],
-              "iterate_over": null,
-              "type_name": "flag_group"
-            }
-          ],
-          "type_name": "flag_set",
-          "with_features": [
-            {
-              "features": [],
-              "not_features": [
-                "kernel_extension"
-              ],
-              "type_name": "with_feature_set"
-            }
-          ]
-        },
-        {
-          "actions": [
-            "objc-executable"
-          ],
-          "flag_groups": [
-            {
               "expand_if_available": "filelist",
               "expand_if_equal": null,
               "expand_if_false": null,

--- a/toolchain/objc/BUILD
+++ b/toolchain/objc/BUILD
@@ -44,18 +44,6 @@ negatable_feature(
 )
 
 cc_args(
-    name = "objc_executable_non_kernel_extension_flags",
-    actions = ["@rules_cc//cc/toolchains/actions:objc_executable"],
-    args = [
-        "-Xlinker",
-        "-objc_abi_version",
-        "-Xlinker",
-        "2",
-    ],
-    requires_any_of = ["//toolchain:not_kernel_extension"],
-)
-
-cc_args(
     name = "objc_executable_filelist_args",
     actions = ["@rules_cc//cc/toolchains/actions:objc_executable"],
     args = [
@@ -111,7 +99,6 @@ cc_args(
 negatable_feature(
     name = "__objc_executable_feature",
     custom_args = [
-        ":objc_executable_non_kernel_extension_flags",
         ":objc_executable_filelist_args",
         ":objc_executable_linked_binary_args",
         ":objc_executable_force_load_args",


### PR DESCRIPTION
This only affected non 32 bit macOS and doesn't seem to be passed by
Xcode anymore unless you set it to not 2, in which case ld rejects it
anyways.
