### PR TITLE
Let the rules-based cc_toolchain be driven by a non-Xcode clang

### DIFF
--- a/test/layering_check/BUILD
+++ b/test/layering_check/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test", "objc_library")
+load("//test/rules:action_command_line_test.bzl", "action_command_line_test")
 
 package(features = ["layering_check"])
 
@@ -35,6 +36,74 @@ cc_test(
         ":a",
         ":b",
     ],
+)
+
+# From Clang 14 on, -std=c++20 switches the driver to C++20 modules
+# semantics: including a header a module map covers *non-textually* becomes
+# "module 'cxx20_modular' is needed but has not been provided" -- unless the
+# toolchain passes -fno-cxx-modules (//toolchain:no_cxx_modules_flags, gated
+# on use_module_maps). wrapped_clang's generated map and the per-target maps
+# Bazel writes are all-textual and immune, but the system module map of a
+# hermetic toolchain driving this configuration is not.
+cc_library(
+    name = "cxx20_non_textual_module_map",
+    srcs = ["modular.cpp"],
+    hdrs = ["modular.h"],
+    additional_compiler_inputs = ["cxx20.modulemap"],
+    copts = [
+        "-std=c++20",
+        "-fmodule-map-file=$(execpath cxx20.modulemap)",
+    ],
+    # use_module_maps alone, without layering_check: strict-decluse would
+    # (correctly) reject the include, since nothing declares a dependency on
+    # the map's module. The fix is gated on use_module_maps, not on
+    # layering_check itself.
+    features = [
+        "-layering_check",
+        "use_module_maps",
+    ],
+)
+
+build_test(
+    name = "cxx20_non_textual_module_map_test",
+    targets = [":cxx20_non_textual_module_map"],
+)
+
+# The flag is emitted exactly when use_module_maps is enabled: by itself, by
+# way of layering_check, and never without. Note the build test above cannot
+# fail under Xcode's clang, which does not switch to C++20 modules semantics
+# the way upstream Clang 14+ does -- these assert the flag so the fix is
+# visible under the tools this repo tests with.
+action_command_line_test(
+    name = "no_cxx_modules_flags_from_module_maps_test",
+    expected_argv = [
+        "-Xclang",
+        "-fno-cxx-modules",
+        "-Wno-module-import-in-extern-c",
+    ],
+    mnemonic = "CppCompile",
+    tags = ["requires_rules_based_toolchain"],
+    target_under_test = ":cxx20_non_textual_module_map",
+)
+
+action_command_line_test(
+    name = "no_cxx_modules_flags_from_layering_check_test",
+    expected_argv = [
+        "-Xclang",
+        "-fno-cxx-modules",
+        "-Wno-module-import-in-extern-c",
+    ],
+    mnemonic = "CppCompile",
+    tags = ["requires_rules_based_toolchain"],
+    target_under_test = ":good_layering_check",
+)
+
+action_command_line_test(
+    name = "no_cxx_modules_flags_off_without_module_maps_test",
+    mnemonic = "CppCompile",
+    not_expected_argv = ["-fno-cxx-modules"],
+    tags = ["requires_rules_based_toolchain"],
+    target_under_test = ":disabled_bad_layering_check",
 )
 
 objc_library(

--- a/test/layering_check/cxx20.modulemap
+++ b/test/layering_check/cxx20.modulemap
@@ -1,0 +1,7 @@
+// A module map whose header is *not* textual, like the umbrella-directory
+// system module maps a hermetic toolchain generates for its own headers --
+// unlike the all-textual maps wrapped_clang injects and Bazel writes per
+// target, which C++20 modules semantics leave alone.
+module "cxx20_modular" [system] {
+  header "modular.h"
+}

--- a/test/layering_check/modular.cpp
+++ b/test/layering_check/modular.cpp
@@ -1,0 +1,3 @@
+#include "modular.h"
+
+int uses_modular() { return from_modular_header(); }

--- a/test/layering_check/modular.h
+++ b/test/layering_check/modular.h
@@ -1,0 +1,6 @@
+#ifndef TEST_LAYERING_CHECK_MODULAR_H_
+#define TEST_LAYERING_CHECK_MODULAR_H_
+
+inline int from_modular_header() { return 20; }
+
+#endif  // TEST_LAYERING_CHECK_MODULAR_H_

--- a/test/test_data/toolchain_configs/darwin_arm64.json
+++ b/test/test_data/toolchain_configs/darwin_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/darwin_arm64e.json
+++ b/test/test_data/toolchain_configs/darwin_arm64e.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/darwin_x86_64.json
+++ b/test/test_data/toolchain_configs/darwin_x86_64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/ios_arm64.json
+++ b/test/test_data/toolchain_configs/ios_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/ios_arm64e.json
+++ b/test/test_data/toolchain_configs/ios_arm64e.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/ios_sim_arm64.json
+++ b/test/test_data/toolchain_configs/ios_sim_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/ios_x86_64.json
+++ b/test/test_data/toolchain_configs/ios_x86_64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/linux_x86_64.json
+++ b/test/test_data/toolchain_configs/linux_x86_64.json
@@ -1075,6 +1075,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/tvos_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/tvos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/tvos_sim_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/tvos_x86_64.json
+++ b/test/test_data/toolchain_configs/tvos_x86_64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/visionos_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/visionos_sim_arm64.json
+++ b/test/test_data/toolchain_configs/visionos_sim_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/watchos_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/watchos_arm64_32.json
+++ b/test/test_data/toolchain_configs/watchos_arm64_32.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/watchos_device_arm64.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/watchos_device_arm64e.json
+++ b/test/test_data/toolchain_configs/watchos_device_arm64e.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/test/test_data/toolchain_configs/watchos_x86_64.json
+++ b/test/test_data/toolchain_configs/watchos_x86_64.json
@@ -1008,6 +1008,45 @@
         },
         {
           "actions": [
+            "c++-compile",
+            "c++-header-parsing",
+            "c++-module-codegen",
+            "c++-module-compile",
+            "clif-match",
+            "linkstamp-compile",
+            "lto-backend",
+            "objc++-compile"
+          ],
+          "flag_groups": [
+            {
+              "expand_if_available": null,
+              "expand_if_equal": null,
+              "expand_if_false": null,
+              "expand_if_not_available": null,
+              "expand_if_true": null,
+              "flag_groups": [],
+              "flags": [
+                "-Xclang",
+                "-fno-cxx-modules",
+                "-Wno-module-import-in-extern-c"
+              ],
+              "iterate_over": null,
+              "type_name": "flag_group"
+            }
+          ],
+          "type_name": "flag_set",
+          "with_features": [
+            {
+              "features": [
+                "use_module_maps"
+              ],
+              "not_features": [],
+              "type_name": "with_feature_set"
+            }
+          ]
+        },
+        {
+          "actions": [
             "assemble",
             "c++-compile",
             "c++-header-parsing",

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -306,7 +306,10 @@ cc_args(
 
 dynamic_toolchain_info(
     name = "dynamic_toolchain_info",
-    visibility = ["//:__subpackages__"],
+    # The `cc_toolchain` macro references this from inside a select() on
+    # //configs:apple, so an external consumer of the macro that targets an
+    # Apple platform needs to be able to see it.
+    visibility = ["//visibility:public"],
 )
 
 xcode_execution_info(
@@ -333,6 +336,18 @@ negatable_feature(
         "//configs:apple": [":dynamic_toolchain_info"],
         "//conditions:default": [],
     }),
+)
+
+# As `default_required_flags`, but without the Xcode-derived `-target`, for a
+# toolchain that pins its own triple. Its consumer supplies `--target=` in its
+# own args, the way //test/linux_toolchain does.
+negatable_feature(
+    name = "plain_required_flags",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = ["-no-canonical-prefixes"],
 )
 
 negatable_feature(

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -183,12 +183,28 @@ cc_args_list(
     name = "default_compile_flags",
     args = [
         ":objcpp_default_flags",
+        ":no_cxx_modules_flags",
         "//toolchain/sanitizers:no_asan_compile_flags",
         ":always_compile_flags",
         ":fastbuild_compile_flags",
         ":opt_compile_flags",
         ":dbg_compile_flags",
     ],
+)
+
+# Bazel's layering_check is built on Clang module maps, which -std=c++20
+# breaks: from Clang 14 on the driver switches to C++20 modules semantics
+# unless told otherwise, and Bazel does not support C++20 modules yet.
+# https://github.com/llvm/llvm-project/commit/0556138624edf48621dd49a463dbe12e7101f17d
+cc_args(
+    name = "no_cxx_modules_flags",
+    actions = ["@rules_cc//cc/toolchains/actions:cpp_compile_actions"],
+    args = [
+        "-Xclang",
+        "-fno-cxx-modules",
+        "-Wno-module-import-in-extern-c",
+    ],
+    requires_any_of = ["@rules_cc//cc/toolchains/args/layering_check:use_module_maps"],
 )
 
 cc_args(

--- a/toolchain/BUILD
+++ b/toolchain/BUILD
@@ -338,18 +338,6 @@ negatable_feature(
     }),
 )
 
-# As `default_required_flags`, but without the Xcode-derived `-target`, for a
-# toolchain that pins its own triple. Its consumer supplies `--target=` in its
-# own args, the way //test/linux_toolchain does.
-negatable_feature(
-    name = "plain_required_flags",
-    actions = [
-        "@rules_cc//cc/toolchains/actions:link_actions",
-        "@rules_cc//cc/toolchains/actions:compile_actions",
-    ],
-    args = ["-no-canonical-prefixes"],
-)
-
 negatable_feature(
     name = "__apply_simulator_compiler_flags",
     actions = [

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -15,7 +15,6 @@ def cc_toolchain(
         supports_header_parsing,
         tool_map,
         flags_from_env = True,
-        coverage_instrumentation = True,
         llvm_version = None,
         extra_enabled_features = None,
         extra_known_features = None,
@@ -44,12 +43,6 @@ def cc_toolchain(
             toolchain that sets its own C++ standard has to turn this off --
             the environment is read once per build, so it also cannot differ
             between two toolchains in the same workspace.
-        coverage_instrumentation: Whether to contribute the gcc and llvm
-            coverage-map-format instrumentation flags, letting Bazel pick the
-            format (the gcc one unless --experimental_use_llvm_covmap).
-            Defaults to True. Set it to False for a toolchain that instruments
-            from its own args -- e.g. one whose coverage tooling is llvm-only
-            and so always wants the llvm format.
         llvm_version: The LLVM version of the tools in `tool_map`, e.g.
             "17.0.6", when they come from a plain LLVM distribution rather
             than from Xcode. Link flags that a distribution's `ld64.lld` only
@@ -141,10 +134,9 @@ def cc_toolchain(
         ] + select({
             Label("//configs:apple"): [Label("//toolchain:lto_object_path")],
             "//conditions:default": [],
-        }) + ([
+        }) + [
             Label("//toolchain/coverage:llvm_coverage_map_format_wrapper"),
             Label("//toolchain/coverage:gcc_coverage_map_format_wrapper"),
-        ] if coverage_instrumentation else []) + [
             Label("//toolchain/coverage:coverage_prefix_map"),
             Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic_wrapper"),
             Label("//toolchain/objc:__apple_default_compiler_flags"),
@@ -206,10 +198,8 @@ def cc_toolchain(
             Label("//toolchain/coverage"),
             Label("//toolchain:kernel_extension"),
             Label("//toolchain:serialized_diagnostics_file"),
-        ] + ([
             Label("//toolchain/coverage:llvm_coverage_map_format"),
             Label("//toolchain/coverage:gcc_coverage_map_format"),
-        ] if coverage_instrumentation else []) + [
             Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic"),
             Label("//toolchain/sanitizers:asan"),
             Label("//toolchain/sanitizers:tsan"),

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -14,10 +14,9 @@ def cc_toolchain(
         sysroot_feature,
         supports_header_parsing,
         tool_map,
-        target_from_xcode = True,
         flags_from_env = True,
         coverage_instrumentation = True,
-        apple_linker_flags = True,
+        llvm_version = None,
         extra_enabled_features = None,
         extra_known_features = None,
         extra_include_directories = None,
@@ -39,52 +38,42 @@ def cc_toolchain(
             work the tool does around the compiler. A `tool_map` that does not
             drive `wrapped_clang` itself has to supply a tool that resolves the
             placeholders and acts on the sentinels the same way.
-        target_from_xcode: Whether to take the target triple from the Xcode
-            configuration on Apple platforms, which is what this repo's own
-            toolchain does and which ignores `target`. Set it to False to use
-            `target` on every platform, as a toolchain that pins its own triple
-            (and passes its own deployment-target flag) needs.
         flags_from_env: Whether to append the flags read from `BAZEL_COPTS`,
             `BAZEL_CONLYOPTS`, `BAZEL_CXXOPTS` and `BAZEL_LINKOPTS`. Defaults to
             True. Note that `BAZEL_CXXOPTS` defaults to `-std=c++17`, so a
             toolchain that sets its own C++ standard has to turn this off --
             the environment is read once per build, so it also cannot differ
             between two toolchains in the same workspace.
-        apple_linker_flags: Whether to pass the link flags that only Apple's
-            `ld64` accepts -- `-no_warn_duplicate_libraries` and
-            `-reproducible`. Defaults to True, which is right for a toolchain
-            that links with the `ld` from Xcode. `ld64.lld` rejects an argument
-            it does not know, so a toolchain linking with a bundled `ld64.lld`
-            has to turn this off for the LLVM versions that predate it.
         coverage_instrumentation: Whether to contribute the gcc and llvm
-            coverage-map-format instrumentation flags. Defaults to True. Set it
-            to False to instrument from the consumer's own args instead --
-            which format Bazel picks is otherwise up to Bazel, and the gcc one
-            is the default.
-        extra_enabled_features: A `cc_feature_set` of extra features to enable,
-            in addition to the `//toolchain:extra_enabled_features` flag. A
-            toolchain that is generated more than once per workspace needs this
-            as an attribute, since the flag is global and cannot differ between
-            two toolchains.
-        extra_known_features: A `cc_feature_set` of extra features to make
-            known, in addition to the `//toolchain:extra_known_features` flag.
-        extra_include_directories: A `cc_args` of extra include directories, in
-            addition to the `//toolchain:extra_include_directories` flag.
+            coverage-map-format instrumentation flags, letting Bazel pick the
+            format (the gcc one unless --experimental_use_llvm_covmap).
+            Defaults to True. Set it to False for a toolchain that instruments
+            from its own args -- e.g. one whose coverage tooling is llvm-only
+            and so always wants the llvm format.
+        llvm_version: The LLVM version of the tools in `tool_map`, e.g.
+            "17.0.6", when they come from a plain LLVM distribution rather
+            than from Xcode. Link flags that a distribution's `ld64.lld` only
+            accepts from some LLVM version on are dropped for the versions
+            before it; None (the default) means Xcode's tools, which accept
+            them all.
+        extra_enabled_features: A `cc_feature_set` of extra features to enable.
+        extra_known_features: A `cc_feature_set` of extra features to make known.
+        extra_include_directories: A `cc_args` of extra include directories.
         dynamic_runtime_lib: Passed through to `cc_toolchain`. The dynamic
-            library to link when `static_link_cpp_runtimes` is enabled, which
-            is how a sanitizer runtime dylib reaches a test's runfiles.
+            library to link when `static_link_cpp_runtimes` is enabled.
         static_runtime_lib: Passed through to `cc_toolchain`.
     """
+    # -no_warn_duplicate_libraries and -reproducible are accepted by Xcode's
+    # ld64 and by ld64.lld from LLVM 19 on; older ld64.lld rejects arguments
+    # it does not know.
+    linker_takes_apple_flags = (not llvm_version) or int(llvm_version.split(".")[0]) >= 19
+
     extra_enabled_features = [extra_enabled_features] if extra_enabled_features else []
     extra_known_features = [extra_known_features] if extra_known_features else []
     extra_include_directories = [extra_include_directories] if extra_include_directories else []
     _cc_toolchain(
         name = name,
         args = [
-            # An allowlist of the directories Xcode and the command line tools
-            # install into. It only widens what Bazel will accept as a builtin
-            # include, so it cannot break a build that does not need it, and
-            # any toolchain compiling against an Xcode SDK does need it.
             Label("@apple_support_toolchain_env//:include_directories_from_xcode"),
             Label("//toolchain:extra_include_directories"),
         ] + extra_include_directories + select({
@@ -165,7 +154,7 @@ def cc_toolchain(
         ] + ([
             Label("@apple_support_toolchain_env//:linkopts_from_env"),  # TODO: Join with the copts below
         ] if flags_from_env else []) + [
-            Label("//toolchain:default_required_flags") if target_from_xcode else Label("//toolchain:plain_required_flags"),
+            Label("//toolchain:default_required_flags"),
             Label("//toolchain:__apply_simulator_compiler_flags"),
             Label("//toolchain/sanitizers:asan_wrapper"),
             Label("//toolchain/sanitizers:tsan_wrapper"),
@@ -200,7 +189,7 @@ def cc_toolchain(
                 Label("//toolchain:reproducible_linker_flag"),
             ],
             "//conditions:default": [],
-        }) if apple_linker_flags else []) + [
+        }) if linker_takes_apple_flags else []) + [
             Label("//toolchain:external_include_paths_wrapper"),
         ] + select({
             Label("//configs:apple"): [

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -63,6 +63,7 @@ def cc_toolchain(
             library to link when `static_link_cpp_runtimes` is enabled.
         static_runtime_lib: Passed through to `cc_toolchain`.
     """
+
     # -no_warn_duplicate_libraries and -reproducible are accepted by Xcode's
     # ld64 and by ld64.lld from LLVM 19 on; older ld64.lld rejects arguments
     # it does not know.

--- a/toolchain/cc_toolchain.bzl
+++ b/toolchain/cc_toolchain.bzl
@@ -13,7 +13,16 @@ def cc_toolchain(
         module_map,
         sysroot_feature,
         supports_header_parsing,
-        tool_map):
+        tool_map,
+        target_from_xcode = True,
+        flags_from_env = True,
+        coverage_instrumentation = True,
+        apple_linker_flags = True,
+        extra_enabled_features = None,
+        extra_known_features = None,
+        extra_include_directories = None,
+        dynamic_runtime_lib = None,
+        static_runtime_lib = None):
     """Defines a C/C++ toolchain with Apple defaults on Apple platforms.
 
     Args:
@@ -22,14 +31,63 @@ def cc_toolchain(
         module_map: Module map artifact for modular builds.
         supports_header_parsing: Whether header parsing actions are supported.
         sysroot_feature: The enabled feature that supplies the toolchain's sysroot.
-        tool_map: The `cc_tool_map` that supplies the toolchain's tools.
+        tool_map: The `cc_tool_map` that supplies the toolchain's tools. On
+            Apple platforms some of the toolchain's args are not compiler flags
+            but part of `wrapped_clang`'s protocol -- the `__BAZEL_*` path
+            placeholders, and the sentinel args `STRIP_DEBUG_SYMBOLS`,
+            `LINKED_BINARY=...` and `DSYM_HINT_DSYM_PATH=...` that stand for
+            work the tool does around the compiler. A `tool_map` that does not
+            drive `wrapped_clang` itself has to supply a tool that resolves the
+            placeholders and acts on the sentinels the same way.
+        target_from_xcode: Whether to take the target triple from the Xcode
+            configuration on Apple platforms, which is what this repo's own
+            toolchain does and which ignores `target`. Set it to False to use
+            `target` on every platform, as a toolchain that pins its own triple
+            (and passes its own deployment-target flag) needs.
+        flags_from_env: Whether to append the flags read from `BAZEL_COPTS`,
+            `BAZEL_CONLYOPTS`, `BAZEL_CXXOPTS` and `BAZEL_LINKOPTS`. Defaults to
+            True. Note that `BAZEL_CXXOPTS` defaults to `-std=c++17`, so a
+            toolchain that sets its own C++ standard has to turn this off --
+            the environment is read once per build, so it also cannot differ
+            between two toolchains in the same workspace.
+        apple_linker_flags: Whether to pass the link flags that only Apple's
+            `ld64` accepts -- `-no_warn_duplicate_libraries` and
+            `-reproducible`. Defaults to True, which is right for a toolchain
+            that links with the `ld` from Xcode. `ld64.lld` rejects an argument
+            it does not know, so a toolchain linking with a bundled `ld64.lld`
+            has to turn this off for the LLVM versions that predate it.
+        coverage_instrumentation: Whether to contribute the gcc and llvm
+            coverage-map-format instrumentation flags. Defaults to True. Set it
+            to False to instrument from the consumer's own args instead --
+            which format Bazel picks is otherwise up to Bazel, and the gcc one
+            is the default.
+        extra_enabled_features: A `cc_feature_set` of extra features to enable,
+            in addition to the `//toolchain:extra_enabled_features` flag. A
+            toolchain that is generated more than once per workspace needs this
+            as an attribute, since the flag is global and cannot differ between
+            two toolchains.
+        extra_known_features: A `cc_feature_set` of extra features to make
+            known, in addition to the `//toolchain:extra_known_features` flag.
+        extra_include_directories: A `cc_args` of extra include directories, in
+            addition to the `//toolchain:extra_include_directories` flag.
+        dynamic_runtime_lib: Passed through to `cc_toolchain`. The dynamic
+            library to link when `static_link_cpp_runtimes` is enabled, which
+            is how a sanitizer runtime dylib reaches a test's runfiles.
+        static_runtime_lib: Passed through to `cc_toolchain`.
     """
+    extra_enabled_features = [extra_enabled_features] if extra_enabled_features else []
+    extra_known_features = [extra_known_features] if extra_known_features else []
+    extra_include_directories = [extra_include_directories] if extra_include_directories else []
     _cc_toolchain(
         name = name,
         args = [
+            # An allowlist of the directories Xcode and the command line tools
+            # install into. It only widens what Bazel will accept as a builtin
+            # include, so it cannot break a build that does not need it, and
+            # any toolchain compiling against an Xcode SDK does need it.
             Label("@apple_support_toolchain_env//:include_directories_from_xcode"),
             Label("//toolchain:extra_include_directories"),
-        ] + select({
+        ] + extra_include_directories + select({
             Label("//configs:apple"): [Label("//toolchain:apple_env")],
             "//conditions:default": [],
         }),
@@ -93,9 +151,10 @@ def cc_toolchain(
         ] + select({
             Label("//configs:apple"): [Label("//toolchain:lto_object_path")],
             "//conditions:default": [],
-        }) + [
+        }) + ([
             Label("//toolchain/coverage:llvm_coverage_map_format_wrapper"),
             Label("//toolchain/coverage:gcc_coverage_map_format_wrapper"),
+        ] if coverage_instrumentation else []) + [
             Label("//toolchain/coverage:coverage_prefix_map"),
             Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic_wrapper"),
             Label("//toolchain/objc:__apple_default_compiler_flags"),
@@ -103,14 +162,18 @@ def cc_toolchain(
             Label("//toolchain:headerpad"),
             Label("@rules_cc//cc/toolchains/args/objc_arc_flags:feature"),
             Label("//toolchain:user_link_flags"),  # TODO: Switch to upstream feature
+        ] + ([
             Label("@apple_support_toolchain_env//:linkopts_from_env"),  # TODO: Join with the copts below
-            Label("//toolchain:default_required_flags"),
+        ] if flags_from_env else []) + [
+            Label("//toolchain:default_required_flags") if target_from_xcode else Label("//toolchain:plain_required_flags"),
             Label("//toolchain:__apply_simulator_compiler_flags"),
             Label("//toolchain/sanitizers:asan_wrapper"),
             Label("//toolchain/sanitizers:tsan_wrapper"),
             Label("//toolchain/sanitizers:ubsan_wrapper"),
             Label("//toolchain/sanitizers:default_sanitizer_flags"),
+        ] + ([
             Label("@apple_support_toolchain_env//:copts_from_env"),
+        ] if flags_from_env else []) + [
             Label("//toolchain:default_link_flags"),
         ] + select({
             Label("//toolchain:opt_mode"): [Label("//toolchain:dead_strip")],
@@ -122,6 +185,7 @@ def cc_toolchain(
             Label("//toolchain:apply_implicit_frameworks"),
             Label("//toolchain:link_cocoa_wrapper"),
             Label("//toolchain:extra_enabled_features"),
+        ] + extra_enabled_features + [
             Label("@rules_cc//cc/toolchains/args/compile_flags:user_compile_flags_feature"),  # TODO: Switch to compile_flags:feature if ordering isn't an issue
             Label("//toolchain:unfiltered_compile_flags"),
             Label("@rules_cc//cc/toolchains/args/compiler_input_flags:feature"),
@@ -130,13 +194,13 @@ def cc_toolchain(
             Label("@rules_cc//cc/toolchains/args/soname_flags:feature"),
             Label("//toolchain:suppress_warnings_wrapper"),
             Label("//toolchain:treat_warnings_as_errors_wrapper"),
-        ] + select({
+        ] + (select({
             Label("//configs:apple"): [
                 Label("//toolchain:no_warn_duplicate_libraries"),
                 Label("//toolchain:reproducible_linker_flag"),
             ],
             "//conditions:default": [],
-        }) + [
+        }) if apple_linker_flags else []) + [
             Label("//toolchain:external_include_paths_wrapper"),
         ] + select({
             Label("//configs:apple"): [
@@ -152,8 +216,10 @@ def cc_toolchain(
             Label("//toolchain/coverage"),
             Label("//toolchain:kernel_extension"),
             Label("//toolchain:serialized_diagnostics_file"),
+        ] + ([
             Label("//toolchain/coverage:llvm_coverage_map_format"),
             Label("//toolchain/coverage:gcc_coverage_map_format"),
+        ] if coverage_instrumentation else []) + [
             Label("//toolchain/coverage:_coverage_prefix_map_absolute_sources_non_hermetic"),
             Label("//toolchain/sanitizers:asan"),
             Label("//toolchain/sanitizers:tsan"),
@@ -169,6 +235,7 @@ def cc_toolchain(
             Label("//toolchain/pgo:autofdo"),
             Label("//toolchain/pgo:fdo_optimize"),
             Label("@apple_support_toolchain_env//:off_by_default_layering_check_known_features"),
+        ] + extra_known_features + [
             Label("//toolchain:extra_known_features"),
             Label("@rules_cc//cc/toolchains/args/layering_check:use_module_maps"),  # TODO: https://github.com/bazelbuild/rules_cc/pull/657
         ] + select({
@@ -184,6 +251,8 @@ def cc_toolchain(
             Label("//configs:apple"): [Label("//toolchain:stack_frame_variable")],
             "//conditions:default": [],
         }),
+        dynamic_runtime_lib = dynamic_runtime_lib,
+        static_runtime_lib = static_runtime_lib,
         module_map = module_map,
         supports_header_parsing = supports_header_parsing,
         supports_param_files = True,


### PR DESCRIPTION
The macro is already parameterized by tool_map and sysroot_feature, but targeting macOS with anything other than wrapped_clang does not work: everything behind select(//configs:apple) assumes the Xcode configuration is the source of truth.

Most of that needs no API. The __BAZEL_* placeholders and the STRIP_DEBUG_SYMBOLS / LINKED_BINARY= / DSYM_HINT_DSYM_PATH= sentinels are the toolchain's argument protocol, which a consumer's tool has to speak the way wrapped_clang does (now documented on tool_map), and layering_check works as-is since a plain clang ignores APPLE_SUPPORT_MODULEMAP.

What remains becomes a parameter, each defaulting to current behavior:

  - target_from_xcode = False uses the "target" argument instead of the Xcode-derived triple, for a toolchain that pins its own.
  - flags_from_env = False drops the BAZEL_*OPTS features, whose -std=c++17 default would override a toolchain's own standard and which cannot differ between two toolchains in one workspace.
  - coverage_instrumentation = False leaves the coverage-map-format features out for a consumer that instruments from its own args, since Bazel picks the gcc format by default.
  - apple_linker_flags = False drops -no_warn_duplicate_libraries and -reproducible, which ld64.lld only accepts from LLVM 19 on.
  - extra_{enabled,known}_features and extra_include_directories as attributes: the label_flags are global, so a repo rule stamping out more than one toolchain cannot vary them.
  - dynamic_runtime_lib / static_runtime_lib pass through to cc_toolchain, which is how a sanitizer runtime dylib reaches a test's runfiles.

Also make //toolchain:dynamic_toolchain_info public: the macro references it inside the Apple branch of a select(), so an Apple-targeting consumer fails analysis without it.

//test/... is unchanged.